### PR TITLE
Refactor entities to use EntityDescriptions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Code Style](https://github.com/dalinicus/homeassistant-acinfinity/actions/workflows/style.yaml/badge.svg)](https://github.com/dalinicus/homeassistant-acinfinity/actions/workflows/style.yaml)
 [![CodeQL](https://github.com/dalinicus/homeassistant-acinfinity/actions/workflows/codeql.yaml/badge.svg)](https://github.com/dalinicus/homeassistant-acinfinity/actions/workflows/codeql.yaml)
 
-This is a custom component for [Home Assistant](http://home-assistant.io) that adds support for [AC Infinity](https://acinfinity.com/) grow tent devices within the [Smart UIS Controller](https://acinfinity.com/smart-controllers/) cloud ecosystem. 
+This is a custom component for [Home Assistant](http://home-assistant.io) that adds support for [AC Infinity](https://acinfinity.com/) grow tent devices within the [Smart UIS Controller](https://acinfinity.com/smart-controllers/) cloud ecosystem.
 
 ## Compatabiliy
 
@@ -64,7 +64,7 @@ Sensors will also be created for each ***PORT*** on a controller, even if no dev
 
 ## Controls
 
-This integration adds a number of controls to modify settings via the AC Infinity API.  The following controls will be created for each ***PORT*** on a controller, even if no device is attached.  The UIS protocol is device type agnostic, so each port will be treated the same regardless of what is plugged (or not plugged) into it.  
+This integration adds a number of controls to modify settings via the AC Infinity API.  The following controls will be created for each ***PORT*** on a controller, even if no device is attached.  The UIS protocol is device type agnostic, so each port will be treated the same regardless of what is plugged (or not plugged) into it.
 
 Currently, controls can be added via the entities card.  The downside is that the controls will still be visible even if they are not applicable to the currently selected mode.  A custom lovelace card is in the works to show and hide controls based on selected mode.  ***Stay tuned!***
 

--- a/custom_components/ac_infinity/__init__.py
+++ b/custom_components/ac_infinity/__init__.py
@@ -55,14 +55,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-async def __raise_not_implemented(_0: ACInfinity, _1: ACInfinityPort, _2: StateType):
-    raise NotImplementedError(
-        "Entity is read-only; `set_value_fn` was not implemented in the entity's description."
-    )
-
-
 @dataclass
-class ACInfinityControllerDescriptionMixin:
+class ACInfinityControllerReadOnlyMixin:
     """Mixin for adding values for controller level sensors"""
 
     get_value_fn: Callable[[ACInfinity, ACInfinityController], StateType]
@@ -70,15 +64,18 @@ class ACInfinityControllerDescriptionMixin:
 
 
 @dataclass
-class ACInfinityPortDescriptionMixin:
+class ACInfinityPortReadOnlyMixin:
     """Mixin for adding values for port device level sensors"""
 
     get_value_fn: Callable[[ACInfinity, ACInfinityPort], StateType]
     """Input data object, device id, and port number; output the value."""
 
-    set_value_fn: Callable[
-        [ACInfinity, ACInfinityPort, StateType], Awaitable[None]
-    ] = __raise_not_implemented
+
+@dataclass
+class ACInfinityPortReadWriteMixin(ACInfinityPortReadOnlyMixin):
+    """Mixin for adding values for port device level sensors"""
+
+    set_value_fn: Callable[[ACInfinity, ACInfinityPort, StateType], Awaitable[None]]
     """Input data object, device id, port number, and desired value."""
 
 
@@ -156,6 +153,10 @@ class ACInfinityControllerEntity(ACInfinityEntity):
     def device_info(self) -> DeviceInfo:
         """Returns the device info for the controller entity"""
         return self._controller.device_info
+    
+    @property
+    def controller(self) -> ACInfinityController:
+        return self._controller
 
 
 class ACInfinityPortEntity(ACInfinityEntity):
@@ -177,3 +178,7 @@ class ACInfinityPortEntity(ACInfinityEntity):
     def device_info(self) -> DeviceInfo:
         """Returns the device info for the port entity"""
         return self._port.device_info
+    
+    @property
+    def port(self) -> ACInfinityPort:
+        return self._port

--- a/custom_components/ac_infinity/ac_infinity.py
+++ b/custom_components/ac_infinity/ac_infinity.py
@@ -88,7 +88,7 @@ class ACInfinityPort:
 
         self._device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{controller._device_id}_{self._port_id}")},
-            name=f"{controller._device_name} {self._port_name}",
+            name=f"{controller.device_name} {self.port_name}",
             manufacturer=MANUFACTURER,
             via_device=controller.identifier,
             model="UIS Enabled Device",

--- a/custom_components/ac_infinity/binary_sensor.py
+++ b/custom_components/ac_infinity/binary_sensor.py
@@ -13,8 +13,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from custom_components.ac_infinity import (
     ACInfinityDataUpdateCoordinator,
-    ACInfinityPortDescriptionMixin,
     ACInfinityPortEntity,
+    ACInfinityPortReadOnlyMixin,
 )
 from custom_components.ac_infinity.const import DOMAIN, SENSOR_PORT_KEY_ONLINE
 
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class ACInfinityPortBinarySensorEntityDescription(
-    BinarySensorEntityDescription, ACInfinityPortDescriptionMixin
+    BinarySensorEntityDescription, ACInfinityPortReadOnlyMixin
 ):
     """Describes ACInfinity Binary Sensor Entities."""
 
@@ -56,11 +56,10 @@ class ACInfinityPortBinarySensorEntity(ACInfinityPortEntity, BinarySensorEntity)
     ) -> None:
         super().__init__(coordinator, port, description.key)
         self.entity_description = description
-        self._port = port
 
     @property
     def is_on(self) -> bool | None:
-        return self.entity_description.get_value_fn(self.ac_infinity, self._port)
+        return self.entity_description.get_value_fn(self.ac_infinity, self.port)
 
 
 async def async_setup_entry(

--- a/custom_components/ac_infinity/binary_sensor.py
+++ b/custom_components/ac_infinity/binary_sensor.py
@@ -1,48 +1,66 @@
 import logging
+from dataclasses import dataclass
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
+    BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from custom_components.ac_infinity import (
     ACInfinityDataUpdateCoordinator,
-    ACInfinityPortPropertyEntity,
+    ACInfinityPortDescriptionMixin,
+    ACInfinityPortEntity,
 )
 from custom_components.ac_infinity.const import DOMAIN, SENSOR_PORT_KEY_ONLINE
 
-from .ac_infinity import ACInfinityDevice, ACInfinityDevicePort
+from .ac_infinity import ACInfinityPort
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class ACInfinityPortBinarySensorEntity(
-    ACInfinityPortPropertyEntity, BinarySensorEntity
+@dataclass
+class ACInfinityPortBinarySensorEntityDescription(
+    BinarySensorEntityDescription, ACInfinityPortDescriptionMixin
 ):
+    """Describes ACInfinity Binary Sensor Entities."""
+
+
+PORT_DESCRIPTIONS: list[ACInfinityPortBinarySensorEntityDescription] = [
+    ACInfinityPortBinarySensorEntityDescription(
+        key=SENSOR_PORT_KEY_ONLINE,
+        device_class=BinarySensorDeviceClass.PLUG,
+        icon="mdi:power",
+        translation_key="port_online",
+        get_value_fn=lambda ac_infinity, port: (
+            ac_infinity.get_device_port_property(
+                port.parent_device_id, port.port_id, SENSOR_PORT_KEY_ONLINE
+            )
+        ),
+    )
+]
+
+
+class ACInfinityPortBinarySensorEntity(ACInfinityPortEntity, BinarySensorEntity):
+    entity_description: ACInfinityPortBinarySensorEntityDescription
+
     def __init__(
         self,
         coordinator: ACInfinityDataUpdateCoordinator,
-        device: ACInfinityDevice,
-        port: ACInfinityDevicePort,
-        data_key: str,
-        label: str,
-        device_class: str,
-        icon: str,
+        description: ACInfinityPortBinarySensorEntityDescription,
+        port: ACInfinityPort,
     ) -> None:
-        super().__init__(coordinator, device, port, data_key, label, icon)
-        self._attr_device_class = device_class
-        self._attr_is_on = self.get_property_value()
+        super().__init__(coordinator, port, description.key)
+        self.entity_description = description
+        self._port = port
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        self._attr_is_on = self.get_property_value()
-        self.async_write_ha_state()
-        _LOGGER.debug(
-            "%s._attr_is_on updated to %s", self._attr_unique_id, self._attr_is_on
-        )
+    @property
+    def is_on(self) -> bool | None:
+        return self.entity_description.get_value_fn(self.ac_infinity, self._port)
 
 
 async def async_setup_entry(
@@ -52,30 +70,20 @@ async def async_setup_entry(
 
     coordinator: ACInfinityDataUpdateCoordinator = hass.data[DOMAIN][config.entry_id]
 
-    device_sensors = {
-        SENSOR_PORT_KEY_ONLINE: {
-            "label": "Status",
-            "deviceClass": BinarySensorDeviceClass.PLUG,
-            "icon": "mdi:power",
-        },
-    }
-
-    devices = coordinator.ac_infinity.get_all_device_meta_data()
+    controllers = coordinator.ac_infinity.get_all_device_meta_data()
 
     entities: list[ACInfinityPortBinarySensorEntity] = []
-    for device in devices:
-        for port in device.ports:
-            for key, descr in device_sensors.items():
-                entities.append(
-                    ACInfinityPortBinarySensorEntity(
-                        coordinator,
-                        device,
-                        port,
-                        key,
-                        descr["label"],
-                        descr["deviceClass"],
-                        descr["icon"],
-                    )
+    for controller in controllers:
+        for port in controller.ports:
+            for description in PORT_DESCRIPTIONS:
+                entity = ACInfinityPortBinarySensorEntity(
+                    coordinator, description, port
+                )
+                entities.append(entity)
+                _LOGGER.info(
+                    'Initializing entity "%s" for platform "%s".',
+                    entity.unique_id,
+                    Platform.BINARY_SENSOR,
                 )
 
     add_entities_callback(entities)

--- a/custom_components/ac_infinity/const.py
+++ b/custom_components/ac_infinity/const.py
@@ -62,3 +62,9 @@ SETTING_KEY_AUTO_TEMP_LOW_TRIGGER_F = "devLtf"
 SETTING_KEY_AUTO_TEMP_LOW_ENABLED = "activeLt"
 SETTING_KEY_AUTO_HUMIDITY_LOW_TRIGGER = "devLh"
 SETTING_KEY_AUTO_HUMIDITY_LOW_ENABLED = "activeLh"
+
+# Schedules are not enabled or disabled by Booleans,
+# but rather disabled when schedule time is set to 65535
+SCHEDULE_DISABLED_VALUE = 65535  # Disabled
+SCHEDULE_MIDNIGHT_VALUE = 0  # 12:00am, default for start time
+SCHEDULE_EOD_VALUE = 1439  # 11:59pm, default for end time

--- a/custom_components/ac_infinity/select.py
+++ b/custom_components/ac_infinity/select.py
@@ -1,66 +1,95 @@
 import logging
+from dataclasses import dataclass
 
-from homeassistant.components.select import SelectEntity
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from custom_components.ac_infinity import (
     ACInfinityDataUpdateCoordinator,
-    ACInfinityPortSettingEntity,
+    ACInfinityPortDescriptionMixin,
+    ACInfinityPortEntity,
 )
 from custom_components.ac_infinity.ac_infinity import (
-    ACInfinityDevice,
-    ACInfinityDevicePort,
+    ACInfinityPort,
 )
 from custom_components.ac_infinity.const import DOMAIN, SETTING_KEY_AT_TYPE
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class ACInfinityPortSelectEntity(ACInfinityPortSettingEntity, SelectEntity):
+@dataclass
+class ACInfinityPortSelectEntityDescription(
+    SelectEntityDescription, ACInfinityPortDescriptionMixin
+):
+    """Describes ACInfinity Select Entities."""
+
+
+MODE_OPTIONS = [
+    "Off",
+    "On",
+    "Auto",
+    "Timer to On",
+    "Timer to Off",
+    "Cycle",
+    "Schedule",
+    "VPD",
+]
+
+PORT_DESCRIPTIONS: list[ACInfinityPortSelectEntityDescription] = [
+    ACInfinityPortSelectEntityDescription(
+        key=SETTING_KEY_AT_TYPE,
+        translation_key="mode_type",
+        options=MODE_OPTIONS,
+        get_value_fn=lambda ac_infinity, port: (
+            MODE_OPTIONS[
+                # data is 1 based.  Adjust to 0 based enum by subtracting 1
+                ac_infinity.get_device_port_setting(
+                    port.parent_device_id, port.port_id, SETTING_KEY_AT_TYPE
+                )
+                - 1
+            ]
+        ),
+        set_value_fn=lambda ac_infinity, port, value: (
+            ac_infinity.set_device_port_setting(
+                port.parent_device_id,
+                port.port_id,
+                SETTING_KEY_AT_TYPE,
+                # data is 1 based.  Adjust from 0 based enum by adding 1
+                MODE_OPTIONS.index(value) + 1,
+            )
+        ),
+    )
+]
+
+
+class ACInfinityPortSelectEntity(ACInfinityPortEntity, SelectEntity):
+    entity_description: ACInfinityPortSelectEntityDescription
+
     def __init__(
         self,
         coordinator: ACInfinityDataUpdateCoordinator,
-        device: ACInfinityDevice,
-        port: ACInfinityDevicePort,
-        data_key: str,
-        label: str,
-        options: list[str],
+        description: ACInfinityPortSelectEntityDescription,
+        port: ACInfinityPort,
     ) -> None:
-        super().__init__(coordinator, device, port, data_key, label, "")
+        super().__init__(coordinator, port, description.key)
+        self.entity_description = description
+        self._port = port
 
-        self._attr_options = options
-        self._attr_current_option = self.__get_option_from_setting_value()
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        self._attr_current_option = self.__get_option_from_setting_value()
-        self.async_write_ha_state()
-        _LOGGER.debug(
-            "%s._attr_current_option updated to %s",
-            self._attr_unique_id,
-            self._attr_current_option,
-        )
+    @property
+    def current_option(self) -> str | None:
+        return self.entity_description.get_value_fn(self.ac_infinity, self._port)
 
     async def async_select_option(self, option: str) -> None:
-        index = self._attr_options.index(option)
-
-        await self.set_setting_value(
-            index + 1
-        )  # data is 1 based.  Adjust from 0 based enum
-        _LOGGER.debug(
-            "User updated value of %s.%s to %s",
-            self._attr_unique_id,
-            self._data_key,
+        _LOGGER.info(
+            'User requesting value update of entity "%s" to "%s"',
+            self.unique_id,
             option,
         )
-
-    def __get_option_from_setting_value(self) -> str:
-        option: int = self.get_setting_value()
-        return self._attr_options[
-            option - 1
-        ]  # data is 1 based.  Adjust for 0 based enum
+        await self.entity_description.set_value_fn(self.ac_infinity, self._port, option)
+        await self.coordinator.async_request_refresh()
 
 
 async def async_setup_entry(
@@ -70,37 +99,18 @@ async def async_setup_entry(
 
     coordintator: ACInfinityDataUpdateCoordinator = hass.data[DOMAIN][config.entry_id]
 
-    select_entities = {
-        SETTING_KEY_AT_TYPE: {
-            "label": "Mode",
-            "options": [
-                "Off",
-                "On",
-                "Auto",
-                "Timer to On",
-                "Timer to Off",
-                "Cycle",
-                "Schedule",
-                "VPD",
-            ],
-        }
-    }
-
-    devices = coordintator.ac_infinity.get_all_device_meta_data()
+    controllers = coordintator.ac_infinity.get_all_device_meta_data()
 
     entities = []
-    for device in devices:
-        for port in device.ports:
-            for key, descr in select_entities.items():
-                entities.append(
-                    ACInfinityPortSelectEntity(
-                        coordintator,
-                        device,
-                        port,
-                        key,
-                        str(descr["label"]),
-                        list[str](descr["options"]),
-                    )
+    for controller in controllers:
+        for port in controller.ports:
+            for description in PORT_DESCRIPTIONS:
+                entity = ACInfinityPortSelectEntity(coordintator, description, port)
+                entities.append(entity)
+                _LOGGER.info(
+                    'Initializing entity "%s" for platform "%s".',
+                    entity.unique_id,
+                    Platform.SELECT,
                 )
 
     add_entities_callback(entities)

--- a/custom_components/ac_infinity/select.py
+++ b/custom_components/ac_infinity/select.py
@@ -9,8 +9,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from custom_components.ac_infinity import (
     ACInfinityDataUpdateCoordinator,
-    ACInfinityPortDescriptionMixin,
     ACInfinityPortEntity,
+    ACInfinityPortReadWriteMixin,
 )
 from custom_components.ac_infinity.ac_infinity import (
     ACInfinityPort,
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class ACInfinityPortSelectEntityDescription(
-    SelectEntityDescription, ACInfinityPortDescriptionMixin
+    SelectEntityDescription, ACInfinityPortReadWriteMixin
 ):
     """Describes ACInfinity Select Entities."""
 
@@ -76,11 +76,10 @@ class ACInfinityPortSelectEntity(ACInfinityPortEntity, SelectEntity):
     ) -> None:
         super().__init__(coordinator, port, description.key)
         self.entity_description = description
-        self._port = port
 
     @property
     def current_option(self) -> str | None:
-        return self.entity_description.get_value_fn(self.ac_infinity, self._port)
+        return self.entity_description.get_value_fn(self.ac_infinity, self.port)
 
     async def async_select_option(self, option: str) -> None:
         _LOGGER.info(
@@ -88,7 +87,7 @@ class ACInfinityPortSelectEntity(ACInfinityPortEntity, SelectEntity):
             self.unique_id,
             option,
         )
-        await self.entity_description.set_value_fn(self.ac_infinity, self._port, option)
+        await self.entity_description.set_value_fn(self.ac_infinity, self.port, option)
         await self.coordinator.async_request_refresh()
 
 

--- a/custom_components/ac_infinity/sensor.py
+++ b/custom_components/ac_infinity/sensor.py
@@ -21,11 +21,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from custom_components.ac_infinity import (
-    ACInfinityControllerDescriptionMixin,
     ACInfinityControllerEntity,
+    ACInfinityControllerReadOnlyMixin,
     ACInfinityDataUpdateCoordinator,
-    ACInfinityPortDescriptionMixin,
     ACInfinityPortEntity,
+    ACInfinityPortReadOnlyMixin,
 )
 from custom_components.ac_infinity.ac_infinity import (
     ACInfinityController,
@@ -46,14 +46,14 @@ _LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class ACInfinityControllerSensorEntityDescription(
-    SensorEntityDescription, ACInfinityControllerDescriptionMixin
+    SensorEntityDescription, ACInfinityControllerReadOnlyMixin
 ):
     """Describes ACInfinity Number Sensor Entities."""
 
 
 @dataclass
 class ACInfinityPortSensorEntityDescription(
-    SensorEntityDescription, ACInfinityPortDescriptionMixin
+    SensorEntityDescription, ACInfinityPortReadOnlyMixin
 ):
     """Describes ACInfinity Number Sensor Entities."""
 
@@ -138,10 +138,10 @@ class ACInfinityControllerSensorEntity(ACInfinityControllerEntity, SensorEntity)
     ) -> None:
         super().__init__(coordinator, controller, description.key)
         self.entity_description = description
-        self._controller = controller
 
+    @property
     def native_value(self) -> StateType | date | datetime | Decimal:
-        return self.entity_description.get_value_fn(self.ac_infinity, self._controller)
+        return self.entity_description.get_value_fn(self.ac_infinity, self.controller)
 
 
 class ACInfinityPortSensorEntity(ACInfinityPortEntity, SensorEntity):
@@ -155,10 +155,10 @@ class ACInfinityPortSensorEntity(ACInfinityPortEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, port, description.key)
         self.entity_description = description
-        self._port = port
 
+    @property
     def native_value(self) -> StateType | date | datetime | Decimal:
-        return self.entity_description.get_value_fn(self.ac_infinity, self._port)
+        return self.entity_description.get_value_fn(self.ac_infinity, self.port)
 
 
 async def async_setup_entry(

--- a/custom_components/ac_infinity/sensor.py
+++ b/custom_components/ac_infinity/sensor.py
@@ -1,25 +1,35 @@
 import logging
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    Platform,
     UnitOfPressure,
     UnitOfTemperature,
     UnitOfTime,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 
 from custom_components.ac_infinity import (
+    ACInfinityControllerDescriptionMixin,
+    ACInfinityControllerEntity,
     ACInfinityDataUpdateCoordinator,
-    ACInfinityDeviceEntity,
-    ACInfinityPortPropertyEntity,
-    ACInfinityPortSettingEntity,
+    ACInfinityPortDescriptionMixin,
+    ACInfinityPortEntity,
 )
 from custom_components.ac_infinity.ac_infinity import (
-    ACInfinityDevice,
-    ACInfinityDevicePort,
+    ACInfinityController,
+    ACInfinityPort,
 )
 
 from .const import (
@@ -34,93 +44,121 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-class ACInfinitySensorEntity(ACInfinityDeviceEntity, SensorEntity):
+@dataclass
+class ACInfinityControllerSensorEntityDescription(
+    SensorEntityDescription, ACInfinityControllerDescriptionMixin
+):
+    """Describes ACInfinity Number Sensor Entities."""
+
+
+@dataclass
+class ACInfinityPortSensorEntityDescription(
+    SensorEntityDescription, ACInfinityPortDescriptionMixin
+):
+    """Describes ACInfinity Number Sensor Entities."""
+
+
+CONTROLLER_DESCRIPTIONS: list[ACInfinityControllerSensorEntityDescription] = [
+    ACInfinityControllerSensorEntityDescription(
+        key=SENSOR_KEY_TEMPERATURE,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        icon=None,  # default
+        translation_key="temperature",
+        get_value_fn=lambda ac_infinity, controller: (
+            # value stored as an integer, but represents a 2 digit precision float
+            ac_infinity.get_device_property(
+                controller.device_id, SENSOR_KEY_TEMPERATURE
+            )
+            / 100
+        ),
+    ),
+    ACInfinityControllerSensorEntityDescription(
+        key=SENSOR_KEY_HUMIDITY,
+        device_class=SensorDeviceClass.HUMIDITY,
+        native_unit_of_measurement=PERCENTAGE,
+        icon=None,  # default
+        translation_key="humidity",
+        get_value_fn=lambda ac_infinity, controller: (
+            # value stored as an integer, but represents a 2 digit precision float
+            ac_infinity.get_device_property(controller.device_id, SENSOR_KEY_HUMIDITY)
+            / 100
+        ),
+    ),
+    ACInfinityControllerSensorEntityDescription(
+        key=SENSOR_KEY_VPD,
+        device_class=SensorDeviceClass.PRESSURE,
+        native_unit_of_measurement=UnitOfPressure.KPA,
+        icon="mdi:water-thermometer",
+        translation_key="vapor_pressure_deficit",
+        get_value_fn=lambda ac_infinity, controller: (
+            # value stored as an integer, but represents a 2 digit precision float
+            ac_infinity.get_device_property(controller.device_id, SENSOR_KEY_VPD)
+            / 100
+        ),
+    ),
+]
+
+PORT_DESCRIPTIONS: list[ACInfinityPortSensorEntityDescription] = [
+    ACInfinityPortSensorEntityDescription(
+        key=SENSOR_PORT_KEY_SPEAK,
+        device_class=SensorDeviceClass.POWER_FACTOR,
+        native_unit_of_measurement=None,  # no units / bare integer value
+        icon=None,  # default
+        translation_key="current_power",
+        get_value_fn=lambda ac_infinity, port: (
+            ac_infinity.get_device_port_property(
+                port.parent_device_id, port.port_id, SENSOR_PORT_KEY_SPEAK
+            )
+        ),
+    ),
+    ACInfinityPortSensorEntityDescription(
+        key=SENSOR_SETTING_KEY_SURPLUS,
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        icon=None,  # default
+        translation_key="remaining_time",
+        get_value_fn=lambda ac_infinity, port: (
+            ac_infinity.get_device_port_setting(
+                port.parent_device_id, port.port_id, SENSOR_SETTING_KEY_SURPLUS
+            )
+        ),
+    ),
+]
+
+
+class ACInfinityControllerSensorEntity(ACInfinityControllerEntity, SensorEntity):
+    entity_description: ACInfinityControllerSensorEntityDescription
+
     def __init__(
         self,
         coordinator: ACInfinityDataUpdateCoordinator,
-        device: ACInfinityDevice,
-        data_key: str,
-        label: str,
-        device_class: str,
-        unit: str,
-        icon: str,
+        description: ACInfinityControllerSensorEntityDescription,
+        controller: ACInfinityController,
     ) -> None:
-        super().__init__(coordinator, device, data_key, label, icon)
+        super().__init__(coordinator, controller, description.key)
+        self.entity_description = description
+        self._controller = controller
 
-        self._attr_device_class = device_class
-        self._attr_native_unit_of_measurement = unit
-        self._attr_native_value = self.__get_property_value_correct_precision()
-
-    def _handle_coordinator_update(self) -> None:
-        self._attr_native_value = self.__get_property_value_correct_precision()
-        self.async_write_ha_state()
-        _LOGGER.debug(
-            "%s._attr_native_value updated to %s",
-            self._attr_unique_id,
-            self._attr_native_value,
-        )
-
-    def __get_property_value_correct_precision(self):
-        # device sensors are all integers representing float values with 2 digit decimal precision
-        return self.get_property_value() / 100
+    def native_value(self) -> StateType | date | datetime | Decimal:
+        return self.entity_description.get_value_fn(self.ac_infinity, self._controller)
 
 
-class ACInfinityPortSensorEntity(ACInfinityPortPropertyEntity, SensorEntity):
+class ACInfinityPortSensorEntity(ACInfinityPortEntity, SensorEntity):
+    entity_description: ACInfinityPortSensorEntityDescription
+
     def __init__(
         self,
         coordinator: ACInfinityDataUpdateCoordinator,
-        device: ACInfinityDevice,
-        port: ACInfinityDevicePort,
-        data_key: str,
-        label: str,
-        device_class: str,
-        unit: str,
-        icon: str,
+        description: ACInfinityPortSensorEntityDescription,
+        port: ACInfinityPort,
     ) -> None:
-        super().__init__(coordinator, device, port, data_key, label, icon)
+        super().__init__(coordinator, port, description.key)
+        self.entity_description = description
+        self._port = port
 
-        self._attr_device_class = device_class
-        self._attr_native_unit_of_measurement = unit
-        self._attr_native_value = self.get_property_value()
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        self._attr_native_value = self.get_property_value()
-        self.async_write_ha_state()
-        _LOGGER.debug(
-            "%s._attr_native_value updated to %s",
-            self._attr_unique_id,
-            self._attr_native_value,
-        )
-
-
-class ACInfinityPortSettingSensorEntity(ACInfinityPortSettingEntity, SensorEntity):
-    def __init__(
-        self,
-        coordinator: ACInfinityDataUpdateCoordinator,
-        device: ACInfinityDevice,
-        port: ACInfinityDevicePort,
-        data_key: str,
-        label: str,
-        device_class: str,
-        unit: str,
-        icon: str,
-    ) -> None:
-        super().__init__(coordinator, device, port, data_key, label, icon)
-
-        self._attr_device_class = device_class
-        self._attr_native_unit_of_measurement = unit
-        self._attr_native_value = self.get_setting_value(default=0)
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        self._attr_native_value = self.get_setting_value(default=0)
-        self.async_write_ha_state()
-        _LOGGER.debug(
-            "%s._attr_native_value updated to %s",
-            self._attr_unique_id,
-            self._attr_native_value,
-        )
+    def native_value(self) -> StateType | date | datetime | Decimal:
+        return self.entity_description.get_value_fn(self.ac_infinity, self._port)
 
 
 async def async_setup_entry(
@@ -130,91 +168,29 @@ async def async_setup_entry(
 
     coordinator: ACInfinityDataUpdateCoordinator = hass.data[DOMAIN][config.entry_id]
 
-    device_sensors = {
-        SENSOR_KEY_TEMPERATURE: {
-            "label": "Temperature",
-            "deviceClass": SensorDeviceClass.TEMPERATURE,
-            "unit": UnitOfTemperature.CELSIUS,
-            "icon": None,  # default
-        },
-        SENSOR_KEY_HUMIDITY: {
-            "label": "Humidity",
-            "deviceClass": SensorDeviceClass.HUMIDITY,
-            "unit": PERCENTAGE,
-            "icon": None,  # default
-        },
-        SENSOR_KEY_VPD: {
-            "label": "VPD",
-            "deviceClass": SensorDeviceClass.PRESSURE,
-            "unit": UnitOfPressure.KPA,
-            "icon": "mdi:water-thermometer",
-        },
-    }
-
-    port_sensors = {
-        SENSOR_PORT_KEY_SPEAK: {
-            "label": "Current Speed",
-            "deviceClass": SensorDeviceClass.POWER_FACTOR,
-            "unit": None,
-            "icon": "mdi:speedometer",
-        }
-    }
-
-    port_setting_sensors = {
-        SENSOR_SETTING_KEY_SURPLUS: {
-            "label": "Remaining Time",
-            "deviceClass": SensorDeviceClass.DURATION,
-            "unit": UnitOfTime.SECONDS,
-            "icon": None,  # default
-        },
-    }
-
-    devices = coordinator.ac_infinity.get_all_device_meta_data()
+    controllers = coordinator.ac_infinity.get_all_device_meta_data()
 
     entities = []
-    for device in devices:
-        # device sensors
-        for key, descr in device_sensors.items():
-            entities.append(
-                ACInfinitySensorEntity(
-                    coordinator,
-                    device,
-                    key,
-                    descr["label"],
-                    descr["deviceClass"],
-                    descr["unit"],
-                    descr["icon"],
-                )
+    for controller in controllers:
+        for description in CONTROLLER_DESCRIPTIONS:
+            entity = ACInfinityControllerSensorEntity(
+                coordinator, description, controller
+            )
+            entities.append(entity)
+            _LOGGER.info(
+                'Initializing entity "%s" for platform "%s".',
+                entity.unique_id,
+                Platform.SENSOR,
             )
 
-        # port sensors
-        for port in device.ports:
-            for key, descr in port_sensors.items():
-                entities.append(
-                    ACInfinityPortSensorEntity(
-                        coordinator,
-                        device,
-                        port,
-                        key,
-                        descr["label"],
-                        descr["deviceClass"],
-                        descr["unit"],
-                        descr["icon"],
-                    )
-                )
-
-            for key, descr in port_setting_sensors.items():
-                entities.append(
-                    ACInfinityPortSettingSensorEntity(
-                        coordinator,
-                        device,
-                        port,
-                        key,
-                        descr["label"],
-                        descr["deviceClass"],
-                        descr["unit"],
-                        descr["icon"],
-                    )
+        for port in controller.ports:
+            for description in PORT_DESCRIPTIONS:
+                entity = ACInfinityPortSensorEntity(coordinator, description, port)
+                entities.append(entity)
+                _LOGGER.info(
+                    'Initializing entity "%s" for platform "%s".',
+                    entity.unique_id,
+                    Platform.SENSOR,
                 )
 
     add_entities_callback(entities)

--- a/custom_components/ac_infinity/switch.py
+++ b/custom_components/ac_infinity/switch.py
@@ -1,20 +1,29 @@
 import logging
+from dataclasses import dataclass
 
-from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from custom_components.ac_infinity import (
     ACInfinityDataUpdateCoordinator,
-    ACInfinityPortSettingEntity,
+    ACInfinityPortDescriptionMixin,
+    ACInfinityPortEntity,
 )
 from custom_components.ac_infinity.ac_infinity import (
-    ACInfinityDevice,
-    ACInfinityDevicePort,
+    ACInfinityPort,
 )
 from custom_components.ac_infinity.const import (
     DOMAIN,
+    SCHEDULE_DISABLED_VALUE,
+    SCHEDULE_EOD_VALUE,
+    SCHEDULE_MIDNIGHT_VALUE,
     SETTING_KEY_AUTO_HUMIDITY_HIGH_ENABLED,
     SETTING_KEY_AUTO_HUMIDITY_LOW_ENABLED,
     SETTING_KEY_AUTO_TEMP_HIGH_ENABLED,
@@ -27,95 +36,222 @@ from custom_components.ac_infinity.const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-DISABLED_VALUE = 65535  # Disabled
-MIDNIGHT_VALUE = 0  # 12:00am
-EOD_VALUE = 1439  # 11:59pm
+
+@dataclass
+class ACInfinityPortSwitchDescriptionMixin:
+    on_value: int
+    off_value: int
 
 
-class ACInfinityPortSwitchEntity(ACInfinityPortSettingEntity, SwitchEntity):
+@dataclass
+class ACInfinityPortSwitchEntityDescription(
+    SwitchEntityDescription,
+    ACInfinityPortDescriptionMixin,
+    ACInfinityPortSwitchDescriptionMixin,
+):
+    """Describes ACInfinity Switch Entities."""
+
+
+PORT_DESCRIPTIONS: list[ACInfinityPortSwitchEntityDescription] = [
+    ACInfinityPortSwitchEntityDescription(
+        key=SETTING_KEY_VPD_HIGH_ENABLED,
+        device_class=SwitchDeviceClass.SWITCH,
+        on_value=1,
+        off_value=0,
+        icon=None,  # default
+        translation_key="vpd_high_enabled",
+        get_value_fn=lambda ac_infinity, port: (
+            ac_infinity.get_device_port_setting(
+                port.parent_device_id, port.port_id, SETTING_KEY_VPD_HIGH_ENABLED
+            )
+        ),
+        set_value_fn=lambda ac_infinity, port, value: (
+            ac_infinity.set_device_port_setting(
+                port.parent_device_id, port.port_id, SETTING_KEY_VPD_HIGH_ENABLED, value
+            )
+        ),
+    ),
+    ACInfinityPortSwitchEntityDescription(
+        key=SETTING_KEY_VPD_LOW_ENABLED,
+        device_class=SwitchDeviceClass.SWITCH,
+        on_value=1,
+        off_value=0,
+        icon=None,  # default
+        translation_key="vpd_low_enabled",
+        get_value_fn=lambda ac_infinity, port: (
+            ac_infinity.get_device_port_setting(
+                port.parent_device_id, port.port_id, SETTING_KEY_VPD_LOW_ENABLED
+            )
+        ),
+        set_value_fn=lambda ac_infinity, port, value: (
+            ac_infinity.set_device_port_setting(
+                port.parent_device_id, port.port_id, SETTING_KEY_VPD_LOW_ENABLED, value
+            )
+        ),
+    ),
+    ACInfinityPortSwitchEntityDescription(
+        key=SETTING_KEY_AUTO_TEMP_HIGH_ENABLED,
+        device_class=SwitchDeviceClass.SWITCH,
+        on_value=1,
+        off_value=0,
+        icon=None,  # default
+        translation_key="auto_temp_high_enabled",
+        get_value_fn=lambda ac_infinity, port: (
+            ac_infinity.get_device_port_setting(
+                port.parent_device_id, port.port_id, SETTING_KEY_AUTO_TEMP_HIGH_ENABLED
+            )
+        ),
+        set_value_fn=lambda ac_infinity, port, value: (
+            ac_infinity.set_device_port_setting(
+                port.parent_device_id,
+                port.port_id,
+                SETTING_KEY_AUTO_TEMP_HIGH_ENABLED,
+                value,
+            )
+        ),
+    ),
+    ACInfinityPortSwitchEntityDescription(
+        key=SETTING_KEY_AUTO_TEMP_LOW_ENABLED,
+        device_class=SwitchDeviceClass.SWITCH,
+        on_value=1,
+        off_value=0,
+        icon=None,  # default
+        translation_key="auto_temp_low_enabled",
+        get_value_fn=lambda ac_infinity, port: (
+            ac_infinity.get_device_port_setting(
+                port.parent_device_id, port.port_id, SETTING_KEY_AUTO_TEMP_LOW_ENABLED
+            )
+        ),
+        set_value_fn=lambda ac_infinity, port, value: (
+            ac_infinity.set_device_port_setting(
+                port.parent_device_id,
+                port.port_id,
+                SETTING_KEY_AUTO_TEMP_LOW_ENABLED,
+                value,
+            )
+        ),
+    ),
+    ACInfinityPortSwitchEntityDescription(
+        key=SETTING_KEY_AUTO_HUMIDITY_HIGH_ENABLED,
+        device_class=SwitchDeviceClass.SWITCH,
+        on_value=1,
+        off_value=0,
+        icon=None,  # default
+        translation_key="auto_humidity_high_enabled",
+        get_value_fn=lambda ac_infinity, port: (
+            ac_infinity.get_device_port_setting(
+                port.parent_device_id,
+                port.port_id,
+                SETTING_KEY_AUTO_HUMIDITY_HIGH_ENABLED,
+            )
+        ),
+        set_value_fn=lambda ac_infinity, port, value: (
+            ac_infinity.set_device_port_setting(
+                port.parent_device_id,
+                port.port_id,
+                SETTING_KEY_AUTO_HUMIDITY_HIGH_ENABLED,
+                value,
+            )
+        ),
+    ),
+    ACInfinityPortSwitchEntityDescription(
+        key=SETTING_KEY_AUTO_HUMIDITY_LOW_ENABLED,
+        device_class=SwitchDeviceClass.SWITCH,
+        on_value=1,
+        off_value=0,
+        icon=None,  # default
+        translation_key="auto_humidity_low_enabled",
+        get_value_fn=lambda ac_infinity, port: (
+            ac_infinity.get_device_port_setting(
+                port.parent_device_id,
+                port.port_id,
+                SETTING_KEY_AUTO_HUMIDITY_LOW_ENABLED,
+            )
+        ),
+        set_value_fn=lambda ac_infinity, port, value: (
+            ac_infinity.set_device_port_setting(
+                port.parent_device_id,
+                port.port_id,
+                SETTING_KEY_AUTO_HUMIDITY_LOW_ENABLED,
+                value,
+            )
+        ),
+    ),
+    ACInfinityPortSwitchEntityDescription(
+        key=SETTING_KEY_SCHEDULED_START_TIME,
+        device_class=SwitchDeviceClass.SWITCH,
+        on_value=SCHEDULE_MIDNIGHT_VALUE,
+        off_value=SCHEDULE_DISABLED_VALUE,
+        icon=None,  # default
+        translation_key="schedule_on_time",
+        get_value_fn=lambda ac_infinity, port: (
+            ac_infinity.get_device_port_setting(
+                port.parent_device_id, port.port_id, SETTING_KEY_SCHEDULED_START_TIME
+            )
+        ),
+        set_value_fn=lambda ac_infinity, port, value: (
+            ac_infinity.set_device_port_setting(
+                port.parent_device_id,
+                port.port_id,
+                SETTING_KEY_SCHEDULED_START_TIME,
+                value,
+            )
+        ),
+    ),
+    ACInfinityPortSwitchEntityDescription(
+        key=SETTING_KEY_SCHEDULED_END_TIME,
+        device_class=SwitchDeviceClass.SWITCH,
+        on_value=SCHEDULE_EOD_VALUE,
+        off_value=SCHEDULE_DISABLED_VALUE,
+        icon=None,  # default
+        translation_key="schedule_off_time",
+        get_value_fn=lambda ac_infinity, port: (
+            ac_infinity.get_device_port_setting(
+                port.parent_device_id, port.port_id, SETTING_KEY_SCHEDULED_END_TIME
+            )
+        ),
+        set_value_fn=lambda ac_infinity, port, value: (
+            ac_infinity.set_device_port_setting(
+                port.parent_device_id,
+                port.port_id,
+                SETTING_KEY_SCHEDULED_END_TIME,
+                value,
+            )
+        ),
+    ),
+]
+
+
+class ACInfinityPortSwitchEntity(ACInfinityPortEntity, SwitchEntity):
+    entity_description: ACInfinityPortSwitchEntityDescription
+
     def __init__(
         self,
         coordinator: ACInfinityDataUpdateCoordinator,
-        device: ACInfinityDevice,
-        port: ACInfinityDevicePort,
-        data_key: str,
-        label: str,
-        icon: str | None,
+        description: ACInfinityPortSwitchEntityDescription,
+        port: ACInfinityPort,
     ) -> None:
-        super().__init__(coordinator, device, port, data_key, label, icon)
-
-        self._attr_device_class = SwitchDeviceClass.SWITCH
-        self._attr_is_on = self.get_setting_value()
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        self._attr_is_on = self.get_setting_value()
-        self.async_write_ha_state()
-        _LOGGER.debug(
-            "%s._attr_native_value updated to %s",
-            self._attr_unique_id,
-            self._attr_is_on,
-        )
+        super().__init__(coordinator, port, description.key)
+        self.entity_description = description
+        self._port = port
 
     async def async_turn_on(self) -> None:
-        await self.set_setting_value(1)
-        _LOGGER.debug(
-            "User switched %s.%s to On",
-            self._attr_unique_id,
-            self._data_key,
+        _LOGGER.info(
+            'User requesting value update of entity "%s" to "On"', self.unique_id
         )
+        await self.entity_description.set_value_fn(
+            self.ac_infinity, self._port, self.entity_description.on_value
+        )
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self) -> None:
-        await self.set_setting_value(0)
-        _LOGGER.debug(
-            "User switched %s.%s to Off",
-            self._attr_unique_id,
-            self._data_key,
+        _LOGGER.info(
+            'User requesting value update of entity "%s" to "Off"', self.unique_id
         )
-
-
-class ACInfinityPortScheduleSwitchEntity(ACInfinityPortSettingEntity):
-    def __init__(
-        self,
-        coordinator: ACInfinityDataUpdateCoordinator,
-        device: ACInfinityDevice,
-        port: ACInfinityDevicePort,
-        data_key: str,
-        label: str,
-        icon: str | None,
-        init_value: int,
-    ) -> None:
-        super().__init__(coordinator, device, port, data_key, label, icon)
-        self._init_value = init_value
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        self._attr_is_on = self.__get_setting_value()
-        self.async_write_ha_state()
-        _LOGGER.debug(
-            "%s._attr_native_value updated to %s",
-            self._attr_unique_id,
-            self._attr_is_on,
+        await self.entity_description.set_value_fn(
+            self.ac_infinity, self._port, self.entity_description.off_value
         )
-
-    async def async_turn_on(self) -> None:
-        await self.set_setting_value(self._init_value)
-        _LOGGER.debug(
-            "User switched %s.%s to On",
-            self._attr_unique_id,
-            self._data_key,
-        )
-
-    async def async_turn_off(self) -> None:
-        await self.set_setting_value(DISABLED_VALUE)
-        _LOGGER.debug(
-            "User switched %s.%s to Off",
-            self._attr_unique_id,
-            self._data_key,
-        )
-
-    def __get_setting_value(self) -> bool:
-        return self.get_setting_value(default=DISABLED_VALUE) <= EOD_VALUE
+        await self.coordinator.async_request_refresh()
 
 
 async def async_setup_entry(
@@ -124,73 +260,18 @@ async def async_setup_entry(
     """Setup the AC Infinity Platform."""
     coordinator: ACInfinityDataUpdateCoordinator = hass.data[DOMAIN][config.entry_id]
 
-    port_entities = {
-        SETTING_KEY_VPD_HIGH_ENABLED: {
-            "label": "VPD High Enabled",
-            "icon": None,  # default
-        },
-        SETTING_KEY_VPD_LOW_ENABLED: {
-            "label": "VPD Low Enabled",
-            "icon": None,  # default
-        },
-        SETTING_KEY_AUTO_TEMP_HIGH_ENABLED: {
-            "label": "Auto High Temp Enabled",
-            "icon": None,  # default
-        },
-        SETTING_KEY_AUTO_TEMP_LOW_ENABLED: {
-            "label": "Auto Low Temp Enabled",
-            "icon": None,  # default
-        },
-        SETTING_KEY_AUTO_HUMIDITY_HIGH_ENABLED: {
-            "label": "Auto Humidity High Enabled",
-            "icon": None,  # default
-        },
-        SETTING_KEY_AUTO_HUMIDITY_LOW_ENABLED: {
-            "label": "Auto Humidity Low Enabled",
-            "icon": None,  # default
-        },
-    }
-
-    schedule_entities = {
-        SETTING_KEY_SCHEDULED_START_TIME: {
-            "label": "Schedule Start Enabled",
-            "icon": None,  # default
-            "init_value": MIDNIGHT_VALUE,
-        },
-        SETTING_KEY_SCHEDULED_END_TIME: {
-            "label": "Schedule End Enabled",
-            "icon": None,  # default
-            "init_value": EOD_VALUE,
-        },
-    }
-
-    devices = coordinator.ac_infinity.get_all_device_meta_data()
+    controllers = coordinator.ac_infinity.get_all_device_meta_data()
 
     entities = []
-    for device in devices:
-        for port in device.ports:
-            for key, descr in port_entities.items():
-                entities.append(
-                    ACInfinityPortSwitchEntity(
-                        coordinator,
-                        device,
-                        port,
-                        key,
-                        str(descr["label"]),
-                        descr["icon"],
-                    )
-                )
-            for schKey, schDescr in schedule_entities.items():
-                entities.append(
-                    ACInfinityPortScheduleSwitchEntity(
-                        coordinator,
-                        device,
-                        port,
-                        schKey,
-                        str(schDescr["label"]),
-                        str(schDescr["icon"]),
-                        int(schDescr["init_value"] or 0),
-                    )
+    for controller in controllers:
+        for port in controller.ports:
+            for description in PORT_DESCRIPTIONS:
+                entity = ACInfinityPortSwitchEntity(coordinator, description, port)
+                entities.append(entity)
+                _LOGGER.info(
+                    'Initializing entity "%s" for platform "%s".',
+                    entity.unique_id,
+                    Platform.SWITCH,
                 )
 
     add_entities_callback(entities)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ homeassistant
 aiohttp
 voluptuous
 datetime
+async_timeout

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,8 +11,8 @@ from homeassistant.helpers.entity import Entity
 from pytest_mock import MockFixture
 
 from custom_components.ac_infinity import (
+    ACInfinityControllerEntity,
     ACInfinityDataUpdateCoordinator,
-    ACInfinityDeviceEntity,
     ACInfinityEntity,
     ACInfinityPortEntity,
 )
@@ -45,9 +45,9 @@ class EntitiesTracker:
         self._added_entities = new_entities
 
 
-async def execute_and_get_device_entity(
+async def execute_and_get_controller_entity(
     setup_fixture, async_setup_entry, property_key: str
-) -> ACInfinityDeviceEntity:
+) -> ACInfinityControllerEntity:
     test_objects: ACTestObjects = setup_fixture
 
     await async_setup_entry(
@@ -59,7 +59,7 @@ async def execute_and_get_device_entity(
     found = [
         sensor
         for sensor in test_objects.entities._added_entities
-        if property_key in sensor._attr_unique_id
+        if property_key in sensor.unique_id
     ]
     assert len(found) == 1
 
@@ -83,8 +83,7 @@ async def execute_and_get_port_entity(
     found = [
         sensor
         for sensor in test_objects.entities._added_entities
-        if sensor._attr_unique_id.endswith(data_key)
-        and f"port_{port}" in sensor._attr_unique_id
+        if sensor.unique_id.endswith(data_key) and f"port_{port}" in sensor.unique_id
     ]
     assert len(found) == 1
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -112,7 +112,7 @@ def setup_entity_mocks(mocker: MockFixture):
     sets_mock = mocker.patch.object(
         ac_infinity, "set_device_port_settings", return_value=future
     )
-    mocker.patch.object(coordinator, "async_request_refresh", return_value=future)
+    refresh_mock = mocker.patch.object(coordinator, "async_request_refresh", return_value=future)
 
     hass.data = {DOMAIN: {ENTRY_ID: coordinator}}
 
@@ -130,6 +130,7 @@ def setup_entity_mocks(mocker: MockFixture):
         sets_mock,
         write_ha_mock,
         coordinator,
+        refresh_mock,
     )
 
 
@@ -144,6 +145,7 @@ class ACTestObjects:
         sets_mock,
         write_ha_mock,
         coordinator,
+        refresh_mock,
     ) -> None:
         self.hass: HomeAssistant = hass
         self.configEntry: ConfigEntry = configEntry
@@ -153,3 +155,4 @@ class ACTestObjects:
         self.sets_mock: MockType = sets_mock
         self.write_ha_mock: MockType = write_ha_mock
         self.coordinator: ACInfinityDataUpdateCoordinator = coordinator
+        self.refresh_mock: MockType = refresh_mock

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -48,12 +48,11 @@ class TestBinarySensors:
             setup, async_setup_entry, port, SENSOR_PORT_KEY_ONLINE
         )
 
-        assert "Status" in sensor._attr_name
         assert (
-            sensor._attr_unique_id
+            sensor.unique_id
             == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{SENSOR_PORT_KEY_ONLINE}"
         )
-        assert sensor._attr_device_class == BinarySensorDeviceClass.PLUG
+        assert sensor.entity_description.device_class == BinarySensorDeviceClass.PLUG
 
     @pytest.mark.parametrize(
         "port,expected",

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,4 +1,5 @@
 import pytest
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
 )
@@ -10,6 +11,7 @@ from custom_components.ac_infinity.binary_sensor import (
 )
 from custom_components.ac_infinity.const import (
     DOMAIN,
+    MANUFACTURER,
     SENSOR_PORT_KEY_ONLINE,
 )
 from custom_components.ac_infinity.sensor import ACInfinityPortSensorEntity
@@ -53,6 +55,7 @@ class TestBinarySensors:
             == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{SENSOR_PORT_KEY_ONLINE}"
         )
         assert sensor.entity_description.device_class == BinarySensorDeviceClass.PLUG
+        assert sensor.device_info is not None
 
     @pytest.mark.parametrize(
         "port,expected",

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -387,9 +387,10 @@ class TestNumbers:
 
         test_objects: ACTestObjects = setup
 
-        sensor: ACInfinityPortEntity = await execute_and_get_port_entity(
+        sensor: ACInfinityPortNumberEntity = await execute_and_get_port_entity(
             setup, async_setup_entry, port, setting
         )
+
         await sensor.async_set_native_value(c)
 
         test_objects.sets_mock.assert_called_with(

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -80,6 +80,8 @@ class TestNumbers:
         assert entity.entity_description.native_min_value == 0
         assert entity.entity_description.native_max_value == 10
 
+        assert entity.device_info is not None
+
     @pytest.mark.parametrize(
         "setting,expected", [(SETTING_KEY_OFF_SPEED, 0), (SETTING_KEY_ON_SPEED, 5)]
     )
@@ -128,6 +130,7 @@ class TestNumbers:
         )
 
         assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
+        assert sensor.device_info is not None
 
     @pytest.mark.parametrize(
         "setting", [SETTING_KEY_TIMER_DURATION_TO_ON, SETTING_KEY_TIMER_DURATION_TO_OFF]
@@ -200,6 +203,7 @@ class TestNumbers:
         )
 
         assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
+        assert sensor.device_info is not None
 
     @pytest.mark.parametrize(
         "setting,enabled_setting",
@@ -278,6 +282,7 @@ class TestNumbers:
         )
 
         assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
+        assert sensor.device_info is not None
 
     @pytest.mark.parametrize(
         "setting", [SETTING_KEY_CYCLE_DURATION_ON, SETTING_KEY_CYCLE_DURATION_OFF]

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -5,6 +5,7 @@ import pytest
 from homeassistant.components.number import NumberDeviceClass
 from pytest_mock import MockFixture
 
+from custom_components.ac_infinity import ACInfinityPortEntity
 from custom_components.ac_infinity.const import (
     DOMAIN,
     SETTING_KEY_AUTO_TEMP_HIGH_TRIGGER,
@@ -24,7 +25,6 @@ from custom_components.ac_infinity.const import (
 )
 from custom_components.ac_infinity.number import (
     ACInfinityPortNumberEntity,
-    ACInfinityPortTempTriggerEntity,
     async_setup_entry,
 )
 from tests import ACTestObjects, execute_and_get_port_entity, setup_entity_mocks
@@ -75,11 +75,10 @@ class TestNumbers:
             setup, async_setup_entry, port, setting
         )
 
-        assert "Speed" in entity._attr_name
-        assert entity._attr_unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{setting}"
-        assert entity._attr_device_class == NumberDeviceClass.POWER_FACTOR
-        assert entity._attr_native_min_value == 0
-        assert entity._attr_native_max_value == 10
+        assert entity.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{setting}"
+        assert entity.entity_description.device_class == NumberDeviceClass.POWER_FACTOR
+        assert entity.entity_description.native_min_value == 0
+        assert entity.entity_description.native_max_value == 10
 
     @pytest.mark.parametrize(
         "setting,expected", [(SETTING_KEY_OFF_SPEED, 0), (SETTING_KEY_ON_SPEED, 5)]
@@ -95,7 +94,7 @@ class TestNumbers:
         )
         entity._handle_coordinator_update()
 
-        assert entity._attr_native_value == expected
+        assert entity.native_value == expected
         test_objects.write_ha_mock.assert_called()
 
     @pytest.mark.parametrize("setting", [SETTING_KEY_OFF_SPEED, SETTING_KEY_ON_SPEED])
@@ -127,8 +126,7 @@ class TestNumbers:
             setup, async_setup_entry, port, key
         )
 
-        assert "Minutes to" in sensor._attr_name
-        assert sensor._attr_unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
+        assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
 
     @pytest.mark.parametrize(
         "setting", [SETTING_KEY_TIMER_DURATION_TO_ON, SETTING_KEY_TIMER_DURATION_TO_OFF]
@@ -156,7 +154,7 @@ class TestNumbers:
         test_objects.ac_infinity._port_settings[str(DEVICE_ID)][port][setting] = value
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_native_value == expected
+        assert sensor.native_value == expected
         test_objects.write_ha_mock.assert_called()
 
     @pytest.mark.parametrize(
@@ -199,8 +197,7 @@ class TestNumbers:
             setup, async_setup_entry, port, key
         )
 
-        assert f"VPD {label} Trigger" in sensor._attr_name
-        assert sensor._attr_unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
+        assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
 
     @pytest.mark.parametrize(
         "setting,enabled_setting",
@@ -227,7 +224,7 @@ class TestNumbers:
         test_objects.ac_infinity._port_settings[str(DEVICE_ID)][port][setting] = value
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_native_value == expected
+        assert sensor.native_value == expected
         test_objects.write_ha_mock.assert_called()
 
     @pytest.mark.parametrize(
@@ -277,8 +274,7 @@ class TestNumbers:
             setup, async_setup_entry, port, key
         )
 
-        assert "Cycle Minutes" in sensor._attr_name
-        assert sensor._attr_unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
+        assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
 
     @pytest.mark.parametrize(
         "setting", [SETTING_KEY_CYCLE_DURATION_ON, SETTING_KEY_CYCLE_DURATION_OFF]
@@ -306,7 +302,7 @@ class TestNumbers:
         test_objects.ac_infinity._port_settings[str(DEVICE_ID)][port][setting] = value
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_native_value == expected
+        assert sensor.native_value == expected
         test_objects.write_ha_mock.assert_called()
 
     @pytest.mark.parametrize(
@@ -367,7 +363,7 @@ class TestNumbers:
         test_objects.ac_infinity._port_settings[str(DEVICE_ID)][port][f_setting] = f
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_native_value == c
+        assert sensor.native_value == c
         test_objects.write_ha_mock.assert_called()
 
     @pytest.mark.parametrize(
@@ -391,7 +387,7 @@ class TestNumbers:
 
         test_objects: ACTestObjects = setup
 
-        sensor: ACInfinityPortTempTriggerEntity = await execute_and_get_port_entity(
+        sensor: ACInfinityPortEntity = await execute_and_get_port_entity(
             setup, async_setup_entry, port, setting
         )
         await sensor.async_set_native_value(c)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -114,6 +114,7 @@ class TestNumbers:
         await entity.async_set_native_value(4)
 
         test_objects.set_mock.assert_called_with(str(DEVICE_ID), port, setting, 4)
+        test_objects.refresh_mock.assert_called()
 
     @pytest.mark.parametrize(
         "key", [SETTING_KEY_TIMER_DURATION_TO_ON, SETTING_KEY_TIMER_DURATION_TO_OFF]
@@ -182,6 +183,7 @@ class TestNumbers:
         test_objects.set_mock.assert_called_with(
             str(DEVICE_ID), port, setting, expected
         )
+        test_objects.refresh_mock.assert_called()
 
     @pytest.mark.parametrize(
         "key,label",
@@ -259,6 +261,7 @@ class TestNumbers:
         test_objects.set_mock.assert_called_with(
             str(DEVICE_ID), port, setting, expected
         )
+        test_objects.refresh_mock.assert_called()
 
     #
     @pytest.mark.parametrize(
@@ -330,6 +333,7 @@ class TestNumbers:
         test_objects.set_mock.assert_called_with(
             str(DEVICE_ID), port, setting, expected
         )
+        test_objects.refresh_mock.assert_called()
 
     @pytest.mark.parametrize(
         "setting, f_setting",
@@ -396,3 +400,4 @@ class TestNumbers:
         test_objects.sets_mock.assert_called_with(
             str(DEVICE_ID), port, [(setting, c), (f_setting, f)]
         )
+        test_objects.refresh_mock.assert_called()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -125,3 +125,4 @@ class TestNumbers:
         test_objects.set_mock.assert_called_with(
             str(DEVICE_ID), port, SETTING_KEY_AT_TYPE, expected
         )
+        test_objects.refresh_mock.assert_called()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -56,6 +56,7 @@ class TestNumbers:
             sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{SETTING_KEY_AT_TYPE}"
         )
         assert len(sensor.entity_description.options) == 8
+        assert sensor.device_info is not None
 
     @pytest.mark.parametrize(
         "atType,expected",

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -52,12 +52,10 @@ class TestNumbers:
             SETTING_KEY_AT_TYPE,
         )
 
-        assert "Mode" in sensor._attr_name
         assert (
-            sensor._attr_unique_id
-            == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{SETTING_KEY_AT_TYPE}"
+            sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{SETTING_KEY_AT_TYPE}"
         )
-        assert len(sensor._attr_options) == 8
+        assert len(sensor.entity_description.options) == 8
 
     @pytest.mark.parametrize(
         "atType,expected",
@@ -91,7 +89,7 @@ class TestNumbers:
         ] = atType
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_current_option == expected
+        assert sensor.current_option == expected
         test_objects.write_ha_mock.assert_called()
 
     @pytest.mark.parametrize(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7,6 +7,11 @@ from homeassistant.const import (
 )
 from pytest_mock import MockFixture
 
+from custom_components.ac_infinity import (
+    ACInfinityControllerEntity,
+    ACInfinityEntity,
+    ACInfinityPortEntity,
+)
 from custom_components.ac_infinity.const import (
     DOMAIN,
     SENSOR_KEY_HUMIDITY,
@@ -17,13 +22,11 @@ from custom_components.ac_infinity.const import (
 )
 from custom_components.ac_infinity.sensor import (
     ACInfinityPortSensorEntity,
-    ACInfinityPortSettingSensorEntity,
-    ACInfinitySensorEntity,
     async_setup_entry,
 )
 from tests import (
     ACTestObjects,
-    execute_and_get_device_entity,
+    execute_and_get_controller_entity,
     execute_and_get_port_entity,
     setup_entity_mocks,
 )
@@ -53,68 +56,70 @@ class TestSensors:
     async def test_async_setup_entry_temperature_created(self, setup):
         """Sensor for device reported temperature is created on setup"""
 
-        sensor: ACInfinitySensorEntity = await execute_and_get_device_entity(
+        sensor: ACInfinityControllerEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_TEMPERATURE
         )
 
-        assert "Temperature" in sensor._attr_name
-        assert sensor._attr_unique_id == f"{DOMAIN}_{MAC_ADDR}_{SENSOR_KEY_TEMPERATURE}"
-        assert sensor._attr_device_class == SensorDeviceClass.TEMPERATURE
-        assert sensor._attr_native_unit_of_measurement == UnitOfTemperature.CELSIUS
+        assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_{SENSOR_KEY_TEMPERATURE}"
+        assert sensor.entity_description.device_class == SensorDeviceClass.TEMPERATURE
+        assert (
+            sensor.entity_description.native_unit_of_measurement
+            == UnitOfTemperature.CELSIUS
+        )
 
     async def test_async_update_temperature_value_Correct(self, setup):
         """Reported sensor value matches the value in the json payload"""
 
-        sensor: ACInfinitySensorEntity = await execute_and_get_device_entity(
+        sensor: ACInfinityControllerEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_TEMPERATURE
         )
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_native_value == 24.17
+        assert sensor.native_value == 24.17
 
     async def test_async_setup_entry_humidity_created(self, setup):
         """Sensor for device reported humidity is created on setup"""
 
-        sensor: ACInfinitySensorEntity = await execute_and_get_device_entity(
+        sensor: ACInfinityControllerEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_HUMIDITY
         )
 
-        assert "Humidity" in sensor._attr_name
-        assert sensor._attr_unique_id == f"{DOMAIN}_{MAC_ADDR}_{SENSOR_KEY_HUMIDITY}"
-        assert sensor._attr_device_class == SensorDeviceClass.HUMIDITY
-        assert sensor._attr_native_unit_of_measurement == PERCENTAGE
+        assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_{SENSOR_KEY_HUMIDITY}"
+        assert sensor.entity_description.device_class == SensorDeviceClass.HUMIDITY
+        assert sensor.entity_description.native_unit_of_measurement == PERCENTAGE
 
     async def test_async_update_humidity_value_Correct(self, setup):
         """Reported sensor value matches the value in the json payload"""
 
-        sensor: ACInfinitySensorEntity = await execute_and_get_device_entity(
+        sensor: ACInfinityControllerEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_HUMIDITY
         )
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_native_value == 72
+        assert sensor.native_value == 72
 
     async def test_async_setup_entry_vpd_created(self, setup):
         """Sensor for device reported humidity is created on setup"""
 
-        sensor: ACInfinitySensorEntity = await execute_and_get_device_entity(
+        sensor: ACInfinityEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_VPD
         )
 
-        assert "VPD" in sensor._attr_name
-        assert sensor._attr_unique_id == f"{DOMAIN}_{MAC_ADDR}_{SENSOR_KEY_VPD}"
-        assert sensor._attr_device_class == SensorDeviceClass.PRESSURE
-        assert sensor._attr_native_unit_of_measurement == UnitOfPressure.KPA
+        assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_{SENSOR_KEY_VPD}"
+        assert sensor.entity_description.device_class == SensorDeviceClass.PRESSURE
+        assert (
+            sensor.entity_description.native_unit_of_measurement == UnitOfPressure.KPA
+        )
 
     async def test_async_update_vpd_value_Correct(self, setup):
         """Reported sensor value matches the value in the json payload"""
 
-        sensor: ACInfinitySensorEntity = await execute_and_get_device_entity(
+        sensor: ACInfinityControllerEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_VPD
         )
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_native_value == 0.83
+        assert sensor.native_value == 0.83
 
     @pytest.mark.parametrize("port", [1, 2, 3, 4])
     async def test_async_setup_entry_current_power_created_for_each_port(
@@ -126,27 +131,25 @@ class TestSensors:
             setup, async_setup_entry, port, SENSOR_PORT_KEY_SPEAK
         )
 
-        assert "Current Speed" in sensor._attr_name
         assert (
-            sensor._attr_unique_id
+            sensor.unique_id
             == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{SENSOR_PORT_KEY_SPEAK}"
         )
-        assert sensor._attr_device_class == SensorDeviceClass.POWER_FACTOR
+        assert sensor.entity_description.device_class == SensorDeviceClass.POWER_FACTOR
 
     @pytest.mark.parametrize("port", [1, 2, 3, 4])
     async def test_async_setup_remaining_time_for_each_port(self, setup, port):
         """Sensor for device port surplus created on setup"""
 
-        sensor: ACInfinityPortSettingSensorEntity = await execute_and_get_port_entity(
+        sensor: ACInfinityPortEntity = await execute_and_get_port_entity(
             setup, async_setup_entry, port, SENSOR_SETTING_KEY_SURPLUS
         )
 
-        assert "Remaining Time" in sensor._attr_name
         assert (
-            sensor._attr_unique_id
+            sensor.unique_id
             == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{SENSOR_SETTING_KEY_SURPLUS}"
         )
-        assert sensor._attr_device_class == SensorDeviceClass.DURATION
+        assert sensor.entity_description.device_class == SensorDeviceClass.DURATION
 
     @pytest.mark.parametrize(
         "port,expected",
@@ -170,14 +173,14 @@ class TestSensors:
         )
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_native_value == expected
+        assert sensor.native_value == expected
 
     @pytest.mark.parametrize("port", [1, 2, 3, 4])
     async def test_async_update_duration_left_value_Correct(self, setup, port):
         """Reported sensor value matches the value in the json payload"""
         test_objects: ACTestObjects = setup
 
-        sensor: ACInfinityPortSettingSensorEntity = await execute_and_get_port_entity(
+        sensor: ACInfinityPortEntity = await execute_and_get_port_entity(
             setup, async_setup_entry, port, SENSOR_SETTING_KEY_SURPLUS
         )
 
@@ -186,5 +189,5 @@ class TestSensors:
         ] = 12345
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_native_value == 12345
+        assert sensor.native_value == 12345
         test_objects.write_ha_mock.assert_called()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -62,6 +62,8 @@ class TestSensors:
             sensor.entity_description.native_unit_of_measurement
             == UnitOfTemperature.CELSIUS
         )
+        assert sensor.device_info is not None
+
 
     async def test_async_update_temperature_value_Correct(self, setup):
         """Reported sensor value matches the value in the json payload"""
@@ -83,6 +85,8 @@ class TestSensors:
         assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_{SENSOR_KEY_HUMIDITY}"
         assert sensor.entity_description.device_class == SensorDeviceClass.HUMIDITY
         assert sensor.entity_description.native_unit_of_measurement == PERCENTAGE
+
+        assert sensor.device_info is not None
 
     async def test_async_update_humidity_value_Correct(self, setup):
         """Reported sensor value matches the value in the json payload"""
@@ -106,6 +110,8 @@ class TestSensors:
         assert (
             sensor.entity_description.native_unit_of_measurement == UnitOfPressure.KPA
         )
+        assert sensor.device_info is not None
+
 
     async def test_async_update_vpd_value_Correct(self, setup):
         """Reported sensor value matches the value in the json payload"""
@@ -146,6 +152,7 @@ class TestSensors:
             == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{SENSOR_SETTING_KEY_SURPLUS}"
         )
         assert sensor.entity_description.device_class == SensorDeviceClass.DURATION
+        assert sensor.device_info is not None
 
     @pytest.mark.parametrize(
         "port,expected",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7,11 +7,6 @@ from homeassistant.const import (
 )
 from pytest_mock import MockFixture
 
-from custom_components.ac_infinity import (
-    ACInfinityControllerEntity,
-    ACInfinityEntity,
-    ACInfinityPortEntity,
-)
 from custom_components.ac_infinity.const import (
     DOMAIN,
     SENSOR_KEY_HUMIDITY,
@@ -21,6 +16,7 @@ from custom_components.ac_infinity.const import (
     SENSOR_SETTING_KEY_SURPLUS,
 )
 from custom_components.ac_infinity.sensor import (
+    ACInfinityControllerSensorEntity,
     ACInfinityPortSensorEntity,
     async_setup_entry,
 )
@@ -56,7 +52,7 @@ class TestSensors:
     async def test_async_setup_entry_temperature_created(self, setup):
         """Sensor for device reported temperature is created on setup"""
 
-        sensor: ACInfinityControllerEntity = await execute_and_get_controller_entity(
+        sensor: ACInfinityControllerSensorEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_TEMPERATURE
         )
 
@@ -70,7 +66,7 @@ class TestSensors:
     async def test_async_update_temperature_value_Correct(self, setup):
         """Reported sensor value matches the value in the json payload"""
 
-        sensor: ACInfinityControllerEntity = await execute_and_get_controller_entity(
+        sensor: ACInfinityControllerSensorEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_TEMPERATURE
         )
         sensor._handle_coordinator_update()
@@ -80,7 +76,7 @@ class TestSensors:
     async def test_async_setup_entry_humidity_created(self, setup):
         """Sensor for device reported humidity is created on setup"""
 
-        sensor: ACInfinityControllerEntity = await execute_and_get_controller_entity(
+        sensor: ACInfinityControllerSensorEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_HUMIDITY
         )
 
@@ -91,7 +87,7 @@ class TestSensors:
     async def test_async_update_humidity_value_Correct(self, setup):
         """Reported sensor value matches the value in the json payload"""
 
-        sensor: ACInfinityControllerEntity = await execute_and_get_controller_entity(
+        sensor: ACInfinityControllerSensorEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_HUMIDITY
         )
         sensor._handle_coordinator_update()
@@ -101,7 +97,7 @@ class TestSensors:
     async def test_async_setup_entry_vpd_created(self, setup):
         """Sensor for device reported humidity is created on setup"""
 
-        sensor: ACInfinityEntity = await execute_and_get_controller_entity(
+        sensor: ACInfinityControllerSensorEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_VPD
         )
 
@@ -114,7 +110,7 @@ class TestSensors:
     async def test_async_update_vpd_value_Correct(self, setup):
         """Reported sensor value matches the value in the json payload"""
 
-        sensor: ACInfinityControllerEntity = await execute_and_get_controller_entity(
+        sensor: ACInfinityControllerSensorEntity = await execute_and_get_controller_entity(
             setup, async_setup_entry, SENSOR_KEY_VPD
         )
         sensor._handle_coordinator_update()
@@ -141,7 +137,7 @@ class TestSensors:
     async def test_async_setup_remaining_time_for_each_port(self, setup, port):
         """Sensor for device port surplus created on setup"""
 
-        sensor: ACInfinityPortEntity = await execute_and_get_port_entity(
+        sensor: ACInfinityPortSensorEntity = await execute_and_get_port_entity(
             setup, async_setup_entry, port, SENSOR_SETTING_KEY_SURPLUS
         )
 
@@ -180,7 +176,7 @@ class TestSensors:
         """Reported sensor value matches the value in the json payload"""
         test_objects: ACTestObjects = setup
 
-        sensor: ACInfinityPortEntity = await execute_and_get_port_entity(
+        sensor: ACInfinityPortSensorEntity = await execute_and_get_port_entity(
             setup, async_setup_entry, port, SENSOR_SETTING_KEY_SURPLUS
         )
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -150,6 +150,7 @@ class TestSwitch:
         test_objects.set_mock.assert_called_with(
             str(DEVICE_ID), port, setting, expected
         )
+        test_objects.refresh_mock.assert_called()
 
     @pytest.mark.parametrize(
         "setting,expected",
@@ -182,3 +183,4 @@ class TestSwitch:
         test_objects.set_mock.assert_called_with(
             str(DEVICE_ID), port, setting, expected
         )
+        test_objects.refresh_mock.assert_called()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -74,6 +74,7 @@ class TestSwitch:
         )
 
         assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{setting}"
+        assert sensor.device_info is not None
 
     @pytest.mark.parametrize(
         "setting,value,expected",

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -16,9 +16,9 @@ from custom_components.ac_infinity.const import (
     SETTING_KEY_VPD_LOW_ENABLED,
 )
 from custom_components.ac_infinity.switch import (
-    DISABLED_VALUE,
-    EOD_VALUE,
-    MIDNIGHT_VALUE,
+    SCHEDULE_DISABLED_VALUE,
+    SCHEDULE_EOD_VALUE,
+    SCHEDULE_MIDNIGHT_VALUE,
     ACInfinityPortSwitchEntity,
     async_setup_entry,
 )
@@ -73,8 +73,7 @@ class TestSwitch:
             setting,
         )
 
-        assert "Enabled" in sensor._attr_name
-        assert sensor._attr_unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{setting}"
+        assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{setting}"
 
     @pytest.mark.parametrize(
         "setting,value,expected",
@@ -86,8 +85,8 @@ class TestSwitch:
             (SETTING_KEY_AUTO_TEMP_LOW_ENABLED, 1, True),
             (SETTING_KEY_VPD_HIGH_ENABLED, 1, True),
             (SETTING_KEY_VPD_LOW_ENABLED, 1, True),
-            (SETTING_KEY_SCHEDULED_START_TIME, MIDNIGHT_VALUE, True),
-            (SETTING_KEY_SCHEDULED_END_TIME, MIDNIGHT_VALUE, True),
+            (SETTING_KEY_SCHEDULED_START_TIME, SCHEDULE_MIDNIGHT_VALUE, True),
+            (SETTING_KEY_SCHEDULED_END_TIME, SCHEDULE_MIDNIGHT_VALUE, True),
             # disabled
             (SETTING_KEY_AUTO_HUMIDITY_HIGH_ENABLED, 0, False),
             (SETTING_KEY_AUTO_HUMIDITY_LOW_ENABLED, 0, False),
@@ -95,8 +94,8 @@ class TestSwitch:
             (SETTING_KEY_AUTO_TEMP_LOW_ENABLED, 0, False),
             (SETTING_KEY_VPD_HIGH_ENABLED, 0, False),
             (SETTING_KEY_VPD_LOW_ENABLED, 0, False),
-            (SETTING_KEY_SCHEDULED_START_TIME, DISABLED_VALUE, False),
-            (SETTING_KEY_SCHEDULED_END_TIME, DISABLED_VALUE, False),
+            (SETTING_KEY_SCHEDULED_START_TIME, SCHEDULE_DISABLED_VALUE, False),
+            (SETTING_KEY_SCHEDULED_END_TIME, SCHEDULE_DISABLED_VALUE, False),
         ],
     )
     @pytest.mark.parametrize("port", [1, 2, 3, 4])
@@ -116,7 +115,7 @@ class TestSwitch:
         test_objects.ac_infinity._port_settings[str(DEVICE_ID)][port][setting] = value
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_is_on == expected
+        assert sensor.is_on == expected
         test_objects.write_ha_mock.assert_called()
 
     @pytest.mark.parametrize(
@@ -129,8 +128,8 @@ class TestSwitch:
             (SETTING_KEY_AUTO_TEMP_LOW_ENABLED, 1),
             (SETTING_KEY_VPD_HIGH_ENABLED, 1),
             (SETTING_KEY_VPD_LOW_ENABLED, 1),
-            (SETTING_KEY_SCHEDULED_START_TIME, MIDNIGHT_VALUE),
-            (SETTING_KEY_SCHEDULED_END_TIME, EOD_VALUE),
+            (SETTING_KEY_SCHEDULED_START_TIME, SCHEDULE_MIDNIGHT_VALUE),
+            (SETTING_KEY_SCHEDULED_END_TIME, SCHEDULE_EOD_VALUE),
         ],
     )
     @pytest.mark.parametrize("port", [1, 2, 3, 4])
@@ -161,8 +160,8 @@ class TestSwitch:
             (SETTING_KEY_AUTO_TEMP_LOW_ENABLED, 0),
             (SETTING_KEY_VPD_HIGH_ENABLED, 0),
             (SETTING_KEY_VPD_LOW_ENABLED, 0),
-            (SETTING_KEY_SCHEDULED_START_TIME, DISABLED_VALUE),
-            (SETTING_KEY_SCHEDULED_END_TIME, DISABLED_VALUE),
+            (SETTING_KEY_SCHEDULED_START_TIME, SCHEDULE_DISABLED_VALUE),
+            (SETTING_KEY_SCHEDULED_END_TIME, SCHEDULE_DISABLED_VALUE),
         ],
     )
     @pytest.mark.parametrize("port", [1, 2, 3, 4])

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -7,6 +7,7 @@ from pytest_mock import MockFixture
 
 from custom_components.ac_infinity.const import (
     DOMAIN,
+    SCHEDULE_DISABLED_VALUE,
     SETTING_KEY_SCHEDULED_END_TIME,
     SETTING_KEY_SCHEDULED_START_TIME,
 )
@@ -109,7 +110,7 @@ class TestTime:
         test_objects.write_ha_mock.assert_called()
 
     @pytest.mark.parametrize(
-        "value, expected", [(None, None), (datetime.time(12, 30), 750)]
+        "value, expected", [(None, SCHEDULE_DISABLED_VALUE), (datetime.time(12, 30), 750)]
     )
     @pytest.mark.parametrize(
         "setting", [SETTING_KEY_SCHEDULED_START_TIME, SETTING_KEY_SCHEDULED_END_TIME]

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -133,3 +133,4 @@ class TestTime:
         test_objects.set_mock.assert_called_with(
             str(DEVICE_ID), port, setting, expected
         )
+        test_objects.refresh_mock.assert_called()

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -54,6 +54,7 @@ class TestTime:
         )
 
         assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
+        assert sensor.device_info is not None
 
     @pytest.mark.parametrize(
         "setting", [SETTING_KEY_SCHEDULED_START_TIME, SETTING_KEY_SCHEDULED_END_TIME]

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -52,9 +52,7 @@ class TestTime:
             setup, async_setup_entry, port, key
         )
 
-        assert "Scheduled" in sensor._attr_name
-        assert "Time" in sensor._attr_name
-        assert sensor._attr_unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
+        assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_port_{port}_{key}"
 
     @pytest.mark.parametrize(
         "setting", [SETTING_KEY_SCHEDULED_START_TIME, SETTING_KEY_SCHEDULED_END_TIME]
@@ -84,9 +82,9 @@ class TestTime:
         test_objects.ac_infinity._port_settings[str(DEVICE_ID)][port][setting] = value
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_native_value
-        assert sensor._attr_native_value.hour == expected_hour
-        assert sensor._attr_native_value.minute == expected_minute
+        assert sensor.native_value
+        assert sensor.native_value.hour == expected_hour
+        assert sensor.native_value.minute == expected_minute
         test_objects.write_ha_mock.assert_called()
 
     @pytest.mark.parametrize(
@@ -107,7 +105,7 @@ class TestTime:
         test_objects.ac_infinity._port_settings[str(DEVICE_ID)][port][setting] = value
         sensor._handle_coordinator_update()
 
-        assert sensor._attr_native_value is None
+        assert sensor.native_value is None
         test_objects.write_ha_mock.assert_called()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
- Refactor entities to use EntityDescriptions instead of manually setting attributes
  - Benefits readability and maintainability
  - Reduces the number of entity classes through the use of getter/setter lambdas
    - Each description is now in charge of transforming its own data to meet the API model, rather than the class object
 - Fix bug with the Select entity where the coordinator wasn't being asked to refresh after changing the value
   - Added code coverage to check for this bug