### PR TITLE
Password Length and kPA Unit fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/custom_components/ac_infinity/client.py
+++ b/custom_components/ac_infinity/client.py
@@ -20,9 +20,14 @@ class ACInfinityClient:
 
     async def login(self):
         headers = self.__create_headers(use_auth_token=False)
+
+        # AC Infinity API does not accept passwords greater than 25 characters.
+        # The Android/iOS app truncates passwords to accommodate for this.  We must do the same.
+        normalized_password: str = self._password[0:25]
+
         response = await self.__post(
             API_URL_LOGIN,
-            {"appEmail": self._email, "appPasswordl": self._password},
+            {"appEmail": self._email, "appPasswordl": normalized_password},
             headers,
         )
         self._user_id = response["data"]["appId"]

--- a/custom_components/ac_infinity/manifest.json
+++ b/custom_components/ac_infinity/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/dalinicus/homeassistant-acinfinity",
   "requirements": [],
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/custom_components/ac_infinity/sensor.py
+++ b/custom_components/ac_infinity/sensor.py
@@ -88,6 +88,7 @@ CONTROLLER_DESCRIPTIONS: list[ACInfinityControllerSensorEntityDescription] = [
     ACInfinityControllerSensorEntityDescription(
         key=SENSOR_KEY_VPD,
         device_class=SensorDeviceClass.PRESSURE,
+        suggested_unit_of_measurement=UnitOfPressure.KPA,
         native_unit_of_measurement=UnitOfPressure.KPA,
         icon="mdi:water-thermometer",
         translation_key="vapor_pressure_deficit",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -117,6 +117,10 @@ class TestSensors:
         assert sensor.unique_id == f"{DOMAIN}_{MAC_ADDR}_{SENSOR_KEY_VPD}"
         assert sensor.entity_description.device_class == SensorDeviceClass.PRESSURE
         assert (
+            sensor.entity_description.suggested_unit_of_measurement
+            == UnitOfPressure.KPA
+        )
+        assert (
             sensor.entity_description.native_unit_of_measurement == UnitOfPressure.KPA
         )
         assert sensor.device_info is not None


### PR DESCRIPTION
- **Fixes an issue with passwords over 25 characters.**  The API only accepts passwords of length 25 or fewer, and it appears the Android/iOS apps just truncate the users password down to 25.  Updates the config flow to do the same so users can log in with their longer than allowed password.  resolves #50 
- **Add suggested unit of measurement to kpa sensor.** Without a suggested unit of measurement, in addition to native unit of measurement, haas defaults the sensor units to psi instead of kPa.  resolves #49 