### PR TITLE
add state_class to select sensors to enable log term statistics

### DIFF
--- a/custom_components/ac_infinity/config_flow.py
+++ b/custom_components/ac_infinity/config_flow.py
@@ -141,6 +141,7 @@ class OptionsFlow(config_entries.OptionsFlow):
         cur_value = (
             int(self.config_entry.data[CONF_POLLING_INTERVAL])
             if CONF_POLLING_INTERVAL in self.config_entry.data
+            and self.config_entry.data[CONF_POLLING_INTERVAL] is not None
             else DEFAULT_POLLING_INTERVAL
         )
 

--- a/custom_components/ac_infinity/manifest.json
+++ b/custom_components/ac_infinity/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/dalinicus/homeassistant-acinfinity",
   "requirements": [],
-  "version": "1.4.2"
+  "version": "1.4.3"
 }

--- a/custom_components/ac_infinity/sensor.py
+++ b/custom_components/ac_infinity/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -62,6 +63,7 @@ CONTROLLER_DESCRIPTIONS: list[ACInfinityControllerSensorEntityDescription] = [
     ACInfinityControllerSensorEntityDescription(
         key=SENSOR_KEY_TEMPERATURE,
         device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         icon=None,  # default
         translation_key="temperature",
@@ -76,6 +78,7 @@ CONTROLLER_DESCRIPTIONS: list[ACInfinityControllerSensorEntityDescription] = [
     ACInfinityControllerSensorEntityDescription(
         key=SENSOR_KEY_HUMIDITY,
         device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
         icon=None,  # default
         translation_key="humidity",
@@ -88,6 +91,7 @@ CONTROLLER_DESCRIPTIONS: list[ACInfinityControllerSensorEntityDescription] = [
     ACInfinityControllerSensorEntityDescription(
         key=SENSOR_KEY_VPD,
         device_class=SensorDeviceClass.PRESSURE,
+        state_class=SensorStateClass.MEASUREMENT,
         suggested_unit_of_measurement=UnitOfPressure.KPA,
         native_unit_of_measurement=UnitOfPressure.KPA,
         icon="mdi:water-thermometer",
@@ -104,6 +108,7 @@ PORT_DESCRIPTIONS: list[ACInfinityPortSensorEntityDescription] = [
     ACInfinityPortSensorEntityDescription(
         key=SENSOR_PORT_KEY_SPEAK,
         device_class=SensorDeviceClass.POWER_FACTOR,
+        state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=None,  # no units / bare integer value
         icon=None,  # default
         translation_key="current_power",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -54,7 +54,7 @@ async def execute_and_get_controller_entity(
 
     await async_setup_entry(
         test_objects.hass,
-        test_objects.configEntry,
+        test_objects.config_entry,
         test_objects.entities.add_entities_callback,
     )
 
@@ -78,7 +78,7 @@ async def execute_and_get_port_entity(
 
     await async_setup_entry(
         test_objects.hass,
-        test_objects.configEntry,
+        test_objects.config_entry,
         test_objects.entities.add_entities_callback,
     )
 
@@ -96,7 +96,6 @@ def setup_entity_mocks(mocker: MockFixture):
     future: Future = asyncio.Future()
     future.set_result(None)
 
-    mocker.patch.object(ConfigEntry, "__init__", return_value=None)
     mocker.patch.object(HomeAssistant, "__init__", return_value=None)
     write_ha_mock = mocker.patch.object(
         Entity, "async_write_ha_state", return_value=None
@@ -120,9 +119,15 @@ def setup_entity_mocks(mocker: MockFixture):
 
     hass.data = {DOMAIN: {ENTRY_ID: coordinator}}
 
-    config_entry = ConfigEntry()
-    config_entry.entry_id = ENTRY_ID
-    config_entry.data = {CONF_EMAIL: ENTRY_ID}
+    config_entry = ConfigEntry(
+        entry_id=ENTRY_ID,
+        data={CONF_EMAIL: ENTRY_ID},
+        domain=DOMAIN,
+        minor_version=0,
+        source="",
+        title="",
+        version=0,
+    )
 
     entities = EntitiesTracker()
 
@@ -156,7 +161,7 @@ class ACTestObjects:
     def __init__(
         self,
         hass,
-        configEntry,
+        config_entry,
         entities,
         ac_infinity,
         set_mock,
@@ -167,7 +172,7 @@ class ACTestObjects:
         options_flow,
     ) -> None:
         self.hass: HomeAssistant = hass
-        self.configEntry: ConfigEntry = configEntry
+        self.config_entry: ConfigEntry = config_entry
         self.entities: EntitiesTracker = entities
         self.ac_infinity: ACInfinity = ac_infinity
         self.set_mock: MockType = set_mock

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -34,7 +34,7 @@ class TestBinarySensors:
 
         await async_setup_entry(
             test_objects.hass,
-            test_objects.configEntry,
+            test_objects.config_entry,
             test_objects.entities.add_entities_callback,
         )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY
 import pytest
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from pytest_mock import MockFixture
 
@@ -24,10 +25,11 @@ from custom_components.ac_infinity.const import (
     CONF_POLLING_INTERVAL,
     CONF_UPDATE_PASSWORD,
     DEFAULT_POLLING_INTERVAL,
+    DOMAIN,
 )
 from tests import ACTestObjects, setup_entity_mocks
 
-from .data_models import EMAIL, PASSWORD, POLLING_INTERVAL
+from .data_models import EMAIL, ENTRY_ID, PASSWORD, POLLING_INTERVAL
 
 CONFIG_FLOW_USER_INPUT = {CONF_EMAIL: EMAIL, CONF_PASSWORD: PASSWORD}
 OPTION_FLOW_USER_INPUT = {CONF_POLLING_INTERVAL: POLLING_INTERVAL}
@@ -141,8 +143,14 @@ class TestConfigFlow:
         self, mocker: MockFixture
     ):
         """options flow returned from static method"""
-        config_entry = mocker.patch.object(
-            config_entries.ConfigEntry, "data", return_value={}
+        config_entry = ConfigEntry(
+            entry_id=ENTRY_ID,
+            data={},
+            domain=DOMAIN,
+            minor_version=0,
+            source="",
+            title="",
+            version=0,
         )
         result = ConfigFlow.async_get_options_flow(config_entry)
 
@@ -157,11 +165,16 @@ class TestConfigFlow:
     ):
         """If no user input provided, async_setup_init should show form with correct value"""
 
-        config_entry = mocker.patch.object(
-            config_entries.ConfigEntry,
-            "data",
-            return_value={CONF_POLLING_INTERVAL: existing_value},
+        config_entry = ConfigEntry(
+            entry_id=ENTRY_ID,
+            data={CONF_POLLING_INTERVAL: existing_value},
+            domain=DOMAIN,
+            minor_version=0,
+            source="",
+            title="",
+            version=0,
         )
+
         flow = OptionsFlow(config_entry)
         await flow.async_step_init()
 
@@ -181,10 +194,16 @@ class TestConfigFlow:
         self, mocker: MockFixture, setup_options_flow
     ):
         """If no user input provided, and no interval exists in settings, async_setup_init should show form with default value"""
-
-        config_entry = mocker.patch.object(
-            config_entries.ConfigEntry, "data", return_value={}
+        config_entry = ConfigEntry(
+            entry_id=ENTRY_ID,
+            data={},
+            domain=DOMAIN,
+            minor_version=0,
+            source="",
+            title="",
+            version=0,
         )
+
         flow = OptionsFlow(config_entry)
         await flow.async_step_init()
 
@@ -208,8 +227,14 @@ class TestConfigFlow:
     ):
         """If provided polling interval is not valid, show form with error"""
 
-        config_entry = mocker.patch.object(
-            config_entries.ConfigEntry, "data", return_value={}
+        config_entry = ConfigEntry(
+            entry_id=ENTRY_ID,
+            data={},
+            domain=DOMAIN,
+            minor_version=0,
+            source="",
+            title="",
+            version=0,
         )
         flow = OptionsFlow(config_entry)
         await flow.async_step_init({CONF_POLLING_INTERVAL: user_input})

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -33,7 +33,6 @@ def setup(mocker: MockFixture):
     mocker.patch.object(ACInfinity, "update", return_value=future)
     mocker.patch.object(ACInfinityClient, "__init__", return_value=None)
     mocker.patch.object(HomeAssistant, "__init__", return_value=None)
-    mocker.patch.object(ConfigEntry, "__init__", return_value=None)
     mocker.patch.object(ConfigEntries, "__init__", return_value=None)
     mocker.patch.object(
         ConfigEntries, "async_forward_entry_setups", return_value=future
@@ -42,28 +41,34 @@ def setup(mocker: MockFixture):
         ConfigEntries, "async_unload_platforms", return_value=boolFuture
     )
 
-    config_entry = ConfigEntry()
-    config_entry.entry_id = ENTRY_ID
-    config_entry.data = {CONF_EMAIL: EMAIL, CONF_PASSWORD: PASSWORD}
+    config_entry = ConfigEntry(
+        entry_id=ENTRY_ID,
+        data={CONF_EMAIL: EMAIL, CONF_PASSWORD: PASSWORD},
+        domain=DOMAIN,
+        minor_version=0,
+        source="",
+        title="",
+        version=0,
+    )
 
     hass = HomeAssistant("/path")
     hass.config_entries = ConfigEntries()
     hass.data = {}
 
-    return (hass, config_entry)
+    return hass, config_entry
 
 
 @pytest.mark.asyncio
 class TestInit:
-    async def test_async_setup_entry_aerogarden_init(self, setup):
-        """when setting up, aerogarden should be initialized and assigned to the hass object"""
+    async def test_async_setup_entry_ac_infinity_init(self, setup):
+        """when setting up, ac_infinity should be initialized and assigned to the hass object"""
         (hass, config_entry) = setup
 
         await async_setup_entry(hass, config_entry)
 
         assert hass.data[DOMAIN][ENTRY_ID] is not None
 
-    async def test_async_setup_entry_platforms_initalized(self, setup):
+    async def test_async_setup_entry_platforms_initialized(self, setup):
         """When setting up, all platforms should be initialized"""
         hass: HomeAssistant
         (hass, config_entry) = setup

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -55,7 +55,7 @@ class TestNumbers:
 
         await async_setup_entry(
             test_objects.hass,
-            test_objects.configEntry,
+            test_objects.config_entry,
             test_objects.entities.add_entities_callback,
         )
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -35,7 +35,7 @@ class TestNumbers:
 
         await async_setup_entry(
             test_objects.hass,
-            test_objects.configEntry,
+            test_objects.config_entry,
             test_objects.entities.add_entities_callback,
         )
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -43,7 +43,7 @@ class TestSensors:
 
         await async_setup_entry(
             test_objects.hass,
-            test_objects.configEntry,
+            test_objects.config_entry,
             test_objects.entities.add_entities_callback,
         )
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -43,7 +43,7 @@ class TestSwitch:
 
         await async_setup_entry(
             test_objects.hass,
-            test_objects.configEntry,
+            test_objects.config_entry,
             test_objects.entities.add_entities_callback,
         )
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -34,7 +34,7 @@ class TestTime:
 
         await async_setup_entry(
             test_objects.hass,
-            test_objects.configEntry,
+            test_objects.config_entry,
             test_objects.entities.add_entities_callback,
         )
 


### PR DESCRIPTION
add state_class to select sensors to enable log term statistics.  This should make them available to the statistics graph card.

Sensors include Temp, Humidity, VPD, and Power Factor.  Surplus specifically excluded as its a countdown to the next schedule phase and would hold little value as a log term statistic.

![image](https://github.com/dalinicus/homeassistant-acinfinity/assets/8620219/62af61e8-d045-4fe9-bef3-c638080bb478)

fixes #46 