### PR TITLE
fix issue with select controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This integration is compatible with the following UIS Controllers
 - Controller 69 Pro
 - Controller 69 Pro+
 
-This integration requires the controller be connected to Wifi, and thus is not compatible with bluetooth only devices such as Controller 67 or the base model of Controller 69, as they do not sync directly to the UIS Cloud
+This integration requires the controller be connected to Wi-fi, and thus is not compatible with bluetooth only devices such as Controller 67 or the base model of Controller 69, as they do not sync directly to the UIS Cloud
 
 # Installation
 
@@ -60,7 +60,7 @@ This integration requires the controller be connected to Wifi, and thus is not c
 
 This integration is made available through the Home Assistant Community Store default feed.  Simply search for "AC Infinity" and install it directly from HACS.
 
-![HACS-Instal](/images/hacs-install.png)
+![HACS-Install](/images/hacs-install.png)
 
 Please see the [official HACS documentation](https://hacs.xyz) for information on how to install and use HACS.
 

--- a/custom_components/ac_infinity/manifest.json
+++ b/custom_components/ac_infinity/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/dalinicus/homeassistant-acinfinity",
   "requirements": [],
-  "version": "1.7.0"
+  "version": "1.8.0"
 }

--- a/custom_components/ac_infinity/select.py
+++ b/custom_components/ac_infinity/select.py
@@ -86,8 +86,7 @@ def __get_value_fn_outside_climate(
 ):
     return OUTSIDE_CLIMATE_OPTIONS[
         entity.ac_infinity.get_controller_setting(
-            controller.device_id,
-            entity.entity_description.key,
+            controller.device_id, entity.entity_description.key, 0
         )
     ]
 
@@ -105,7 +104,7 @@ def __set_value_fn_outside_climate(
 def __get_value_fn_setting_mode(entity: ACInfinityEntity, port: ACInfinityPort):
     return SETTINGS_MODE_OPTIONS[
         entity.ac_infinity.get_port_control(
-            port.controller.device_id, port.port_index, entity.entity_description.key
+            port.controller.device_id, port.port_index, entity.entity_description.key, 0
         )
     ]
 
@@ -125,7 +124,7 @@ def __get_value_fn_active_mode(entity: ACInfinityEntity, port: ACInfinityPort):
     return MODE_OPTIONS[
         # data is 1 based.  Adjust to 0 based enum by subtracting 1
         entity.ac_infinity.get_port_control(
-            port.controller.device_id, port.port_index, PortControlKey.AT_TYPE
+            port.controller.device_id, port.port_index, PortControlKey.AT_TYPE, 1
         )
         - 1
     ]
@@ -151,6 +150,7 @@ def __get_value_fn_dynamic_response_type(
             port.controller.device_id,
             port.port_index,
             AdvancedSettingsKey.DYNAMIC_RESPONSE_TYPE,
+            0,
         )
     ]
 
@@ -168,7 +168,10 @@ def __set_value_fn_dynamic_response_type(
 
 def __get_value_fn_device_load_type(entity: ACInfinityEntity, port: ACInfinityPort):
     value = entity.ac_infinity.get_port_setting(
-        port.controller.device_id, port.port_index, AdvancedSettingsKey.DEVICE_LOAD_TYPE
+        port.controller.device_id,
+        port.port_index,
+        AdvancedSettingsKey.DEVICE_LOAD_TYPE,
+        1,
     )
 
     return DEVICE_LOAD_TYPE_OPTIONS.get(value, "Unknown Device Type")

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -93,7 +93,7 @@ class TestSelectors:
 
     @pytest.mark.parametrize(
         "value,expected",
-        [(0, "Neutral"), (1, "Lower"), (2, "Higher")],
+        [(None, "Neutral"), (0, "Neutral"), (1, "Lower"), (2, "Higher")],
     )
     @pytest.mark.parametrize(
         "setting",
@@ -157,6 +157,7 @@ class TestSelectors:
     @pytest.mark.parametrize(
         "at_type,expected",
         [
+            (None, "Off"),
             (1, "Off"),
             (2, "On"),
             (3, "Auto"),
@@ -230,6 +231,7 @@ class TestSelectors:
     @pytest.mark.parametrize(
         "value,expected",
         [
+            (None, "Transition"),
             (0, "Transition"),
             (1, "Buffer"),
         ],
@@ -291,6 +293,7 @@ class TestSelectors:
     @pytest.mark.parametrize(
         "load_type,expected",
         [
+            (None, "Grow Light"),
             (1, "Grow Light"),
             (2, "Humidifier"),
             (3, "Unknown Device Type"),
@@ -381,6 +384,7 @@ class TestSelectors:
     @pytest.mark.parametrize(
         "setting_mode,expected",
         [
+            (None, "Auto"),
             (0, "Auto"),
             (1, "Target"),
         ],


### PR DESCRIPTION
The response from AC Infinity API can contain None values for fields that expect an enum integer value, resulting in an invalid enum lookup.  Fixes the getters so that they account for a default value if None is encountered.

resolves #81 