### PR TITLE
Use UnitOfRatio.PARTS_PER_MILLION over deprecated CONCENTRATION_PARTS_PER_MILLION

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -22,7 +22,10 @@ jobs:
       - uses: actions/setup-python@v5
         name: Setup Python
         with:
-          python-version: 3.13
+          # Home Assistant 2026.7+ requires Python >= 3.14.2, and requirements.txt
+          # installs `homeassistant` unpinned. On 3.13 pip resolves the newest HA
+          # that still supports 3.13 (2026.2.x), which predates UnitOfRatio.
+          python-version: "3.14"
       - name: Update pip
         run: python -m pip install --upgrade pip
       - name: Install dependencies

--- a/custom_components/ac_infinity/sensor.py
+++ b/custom_components/ac_infinity/sensor.py
@@ -12,11 +12,11 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
     Platform,
     UnitOfConductivity,
     UnitOfPressure,
+    UnitOfRatio,
     UnitOfTemperature,
     UnitOfTime,
 )
@@ -375,7 +375,7 @@ SENSOR_DESCRIPTIONS: dict[int, ACInfinitySensorSensorEntityDescription] = {
         key=SensorReferenceKey.CO2_SENSOR,
         device_class=SensorDeviceClass.CO2,
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
         suggested_unit_of_measurement=None,
         icon=None,  # default
         translation_key="co2_sensor",
@@ -447,7 +447,7 @@ SENSOR_DESCRIPTIONS: dict[int, ACInfinitySensorSensorEntityDescription] = {
         key=SensorReferenceKey.HYDRO_TDS,
         device_class=None,
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
         suggested_unit_of_measurement=None,
         icon=MdiIcon.WATER_OPACITY,
         translation_key="hydro_tds_sensor",

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
     "name": "AC Infinity",
+    "homeassistant": "2026.7.0",
     "render_readme": true,
     "zip_release": true,
     "filename": "ac_infinity.zip"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,57 @@
+"""Shared test fixtures and compatibility shims.
+
+Installs a small aioresponses/aiohttp compatibility shim; see
+``_patch_client_response_for_aioresponses`` below.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from aiohttp.client_reqrep import ClientResponse
+
+
+class _NullStreamWriter:
+    """Stand-in for the stream writer aiohttp>=3.13 reads on construction.
+
+    A mocked response is never actually written to the wire, so aiohttp only
+    reads ``output_size`` off this object (client_reqrep records it when the
+    request was "already sent").
+    """
+
+    output_size = 0
+
+
+def _patch_client_response_for_aioresponses() -> None:
+    """Let aioresponses build responses on aiohttp>=3.13.
+
+    aiohttp 3.13 added a required keyword-only ``stream_writer`` argument to
+    ``ClientResponse.__init__``. aioresponses (through 0.7.9, current) does
+    not pass it, so every mocked request in tests/test_client.py dies with::
+
+        TypeError: ClientResponse.__init__() missing 1 required
+        keyword-only argument: 'stream_writer'
+
+    Default that kwarg rather than capping the test-time aiohttp: this
+    integration's runtime dependency is uncapped, so pinning the tests to an
+    old aiohttp would mean never exercising the version users actually run.
+
+    The shim is self-limiting in both directions -- on aiohttp<3.13 the
+    parameter does not exist and we skip patching entirely, and once
+    aioresponses passes ``stream_writer`` itself the ``setdefault`` becomes a
+    no-op. Remove it once aioresponses supports aiohttp>=3.13 natively.
+    """
+    if "stream_writer" not in inspect.signature(ClientResponse.__init__).parameters:
+        return
+
+    original_init = ClientResponse.__init__
+
+    def _init(self: ClientResponse, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("stream_writer", _NullStreamWriter())
+        original_init(self, *args, **kwargs)
+
+    ClientResponse.__init__ = _init  # type: ignore[method-assign]
+
+
+_patch_client_response_for_aioresponses()


### PR DESCRIPTION
On Home Assistant 2026.8.x the integration logs this on every start:

```
[homeassistant.const] The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from ac_infinity. It will be removed in HA Core 2027.8. Use UnitOfRatio.PARTS_PER_MILLION instead, please report it to the author of the 'ac_infinity' custom integration
```

`CONCENTRATION_PARTS_PER_MILLION` was deprecated in [core#175189](https://github.com/home-assistant/core/pull/175189) and is removed in **HA Core 2027.8**. This swaps the two uses (`SensorType.CO2` and `SensorType.HYDRO_TDS_PPM`) to `UnitOfRatio.PARTS_PER_MILLION`.

The enum member's value is byte-identical (`"ppm"`), so **no unit string, entity state, or recorded statistic changes** — the deprecated constant is already just an alias for it.

### Why this needs a version floor

`UnitOfRatio` first exists in HA **2026.7.0** (I checked `homeassistant/const.py` at the release tags — it is absent at 2026.6.0). HA 2026.7 in turn declares `requires-python = ">=3.14.2"`. Two consequences, both handled here:

**1. `hacs.json` gains `"homeassistant": "2026.7.0"`.** The repo currently declares no floor, so without this HACS would offer the update to users on older cores, where the import raises `ImportError` at setup.

**2. `quality.yaml` moves Python 3.13 → 3.14.** This one is not cosmetic. `requirements.txt` installs `homeassistant` unpinned, so on 3.13 pip resolves the newest core that still supports 3.13 — which predates `UnitOfRatio`:

```
$ python3.13 -m pip install homeassistant && python -c "from homeassistant.const import UnitOfRatio"
# resolves homeassistant 2026.2.3
ImportError: cannot import name 'UnitOfRatio' from 'homeassistant.const'
```

Without the bump, CI would go red on this PR for that reason alone.

### The first commit is a prerequisite, and is independently useful

Moving CI to 3.14 pulls in a modern `aiohttp`, which surfaces **52 failures in `tests/test_client.py`** that have nothing to do with this change:

```
TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'
```

`aiohttp` 3.13 added a required keyword-only `stream_writer` to `ClientResponse.__init__`, and `aioresponses` (through 0.7.9, current) does not pass it. It is latent today only because the CI pin holds `aiohttp` back. The first commit adds a `tests/conftest.py` shim that defaults the kwarg, rather than capping the test-time `aiohttp` — pinning the tests would mean never exercising the `aiohttp` your users actually install. It is self-limiting in both directions: on `aiohttp<3.13` the parameter does not exist and patching is skipped, and once `aioresponses` passes `stream_writer` itself the `setdefault` becomes a no-op.

It is a separate commit so you can take it on its own, or drop it if you would rather pin.

### Verification

Measured on this branch, so the migration's effect is isolated:

| Tree | Python | Result |
|---|---|---|
| `main` | 3.13 (current CI) | 252 passed |
| `main` | 3.14 | 199 passed, **52 failed** (`stream_writer`) |
| `main` + conftest shim | 3.14 | **251 passed, 0 failed** |
| this PR (shim + migration) | 3.14 | **251 passed, 0 failed** |

The last two rows are identical, so the unit migration itself introduces no test change. The 252 → 251 difference between rows 1 and 3 is the HA version jump (2026.2.3 → 2026.8.1), not either commit here.

One note in fairness: there is a large, constant count of `RuntimeError: There is no current event loop in thread 'MainThread'` teardown errors in my local runs, present identically on unmodified `main`. They look environmental and I did not chase them, but I did not want to quietly omit them — they are unchanged by this PR.

Happy to drop the `hacs.json` floor or the CI bump into a separate PR, or adjust anything here, if you would prefer a different shape.
