### PR TITLE
Skip no-op writes and space out consecutive update calls

### DIFF
--- a/custom_components/ac_infinity/client.py
+++ b/custom_components/ac_infinity/client.py
@@ -1,5 +1,7 @@
+import asyncio
 import json
 import logging
+from time import monotonic
 from urllib.parse import urlencode
 
 import aiohttp
@@ -18,6 +20,11 @@ API_URL_MODE_AND_SETTINGS = "/api/dev/modeAndSetting"
 API_URL_GET_DEV_SETTING = "/api/dev/getDevSetting"
 API_URL_UPDATE_ADV_SETTING = "/api/dev/updateAdvSetting"
 
+# Minimum delay between consecutive write requests to the AC Infinity API.  Writes
+# issued back to back can trip a server-side failure window in which subsequent
+# update calls are rejected with code 100001 (see issues #39 and #109).
+MINIMUM_WRITE_SPACING_SECONDS = 5.0
+
 
 class ACInfinityClient:
     """Encapsulates http calls to the AC Infinity API"""
@@ -34,6 +41,8 @@ class ACInfinityClient:
         self._password = password
         self._user_id: str | None = None
         self._session: aiohttp.ClientSession | None = None
+        self._write_lock = asyncio.Lock()
+        self._last_write_monotonic: float | None = None
 
     async def login(self):
         """Call the log in endpoint with the configured email and password, and obtain the user id to use for subsequent calls"""
@@ -116,19 +125,29 @@ class ACInfinityClient:
         self.__ensure_logged_in()
 
         headers = self.__create_headers(use_auth_token=True)
-        body = await self.__post(
-            API_URL_GET_DEV_MODE_SETTING, {"devId": controller_id, "port": device_port}, headers
-        )
-        existing_values = body["data"]
+        async with self._write_lock:
+            body = await self.__post(
+                API_URL_GET_DEV_MODE_SETTING, {"devId": controller_id, "port": device_port}, headers
+            )
+            existing_values = body["data"]
 
-        device_control_keys: list[str] = [
-            getattr(DeviceControlKey, attr)
-            for attr in dir(DeviceControlKey)
-            if not attr.startswith('_')
-        ]
+            device_control_keys: list[str] = [
+                getattr(DeviceControlKey, attr)
+                for attr in dir(DeviceControlKey)
+                if not attr.startswith('_')
+            ]
 
-        updated = self.__transfer_values(device_control_keys, key_values, existing_values)
-        _ = await self.__post(f"{API_URL_ADD_DEV_MODE}?{urlencode(updated)}", None, headers)
+            current = self.__transfer_values(device_control_keys, {}, existing_values)
+            updated = self.__transfer_values(device_control_keys, key_values, existing_values)
+            if updated == current:
+                _LOGGER.debug(
+                    "Skipping device control update for controller %s port %s; values already match",
+                    controller_id, device_port,
+                )
+                return
+
+            await self.__apply_write_spacing()
+            _ = await self.__post(f"{API_URL_ADD_DEV_MODE}?{urlencode(updated)}", None, headers)
 
     async def update_device_settings(
         self, controller_id: str | int, device_port: int, device_name: str, key_values: dict[str, int]
@@ -144,21 +163,31 @@ class ACInfinityClient:
         self.__ensure_logged_in()
 
         headers = self.__create_headers(use_auth_token=True)
-        body = await self.__post(
-            API_URL_GET_DEV_SETTING, {"devId": controller_id, "port": device_port}, headers
-        )
-        existing_values = body["data"]
+        async with self._write_lock:
+            body = await self.__post(
+                API_URL_GET_DEV_SETTING, {"devId": controller_id, "port": device_port}, headers
+            )
+            existing_values = body["data"]
 
-        device_settings_keys: list[str] = [
-            getattr(AdvancedSettingsKey, attr)
-            for attr in dir(AdvancedSettingsKey)
-            if not attr.startswith('_')
-        ]
+            device_settings_keys: list[str] = [
+                getattr(AdvancedSettingsKey, attr)
+                for attr in dir(AdvancedSettingsKey)
+                if not attr.startswith('_')
+            ]
 
-        updated = self.__transfer_values(device_settings_keys, key_values, existing_values)
-        updated[AdvancedSettingsKey.DEV_NAME] = device_name
+            current = self.__transfer_values(device_settings_keys, {}, existing_values)
+            current[AdvancedSettingsKey.DEV_NAME] = device_name
+            updated = self.__transfer_values(device_settings_keys, key_values, existing_values)
+            updated[AdvancedSettingsKey.DEV_NAME] = device_name
+            if updated == current:
+                _LOGGER.debug(
+                    "Skipping device settings update for controller %s port %s; values already match",
+                    controller_id, device_port,
+                )
+                return
 
-        _ = await self.__post(f"{API_URL_UPDATE_ADV_SETTING}?{urlencode(updated)}", None, headers)
+            await self.__apply_write_spacing()
+            _ = await self.__post(f"{API_URL_UPDATE_ADV_SETTING}?{urlencode(updated)}", None, headers)
 
     async def update_ai_device_control_and_settings(
         self, controller_id: str | int, device_port: int, key_values: dict[str, int]
@@ -173,6 +202,14 @@ class ACInfinityClient:
         self.__ensure_logged_in()
 
         headers = self.__create_headers(use_auth_token=True, use_min_version=True)
+        async with self._write_lock:
+            await self.__update_ai_device_control_and_settings_locked(
+                controller_id, device_port, key_values, headers
+            )
+
+    async def __update_ai_device_control_and_settings_locked(
+        self, controller_id: str | int, device_port: int, key_values: dict[str, int], headers: dict
+    ):
         body = await self.__post(
             API_URL_GET_DEV_MODE_SETTING, {"devId": controller_id, "port": device_port}, headers
         )
@@ -187,7 +224,14 @@ class ACInfinityClient:
             if not attr.startswith('_')
         ]
 
+        current = self.__transfer_values(device_control_keys, {}, flattened)
         updated = self.__transfer_values(device_control_keys, key_values, flattened)
+        if updated == current:
+            _LOGGER.debug(
+                "Skipping ai device control update for controller %s port %s; values already match",
+                controller_id, device_port,
+            )
+            return
 
         at_type = updated[DeviceControlKey.AT_TYPE]
         match at_type:
@@ -206,8 +250,17 @@ class ACInfinityClient:
             case _:
                 raise ValueError(f"Unable to find setting id string - Unknown atType {at_type}")
 
+        await self.__apply_write_spacing()
         url = f"{API_URL_MODE_AND_SETTINGS}?{urlencode(updated)}"
         _ = await self.__put(url, headers)
+
+    async def __apply_write_spacing(self) -> None:
+        """Wait until at least MINIMUM_WRITE_SPACING_SECONDS has passed since the last write request."""
+        if self._last_write_monotonic is not None:
+            remaining = MINIMUM_WRITE_SPACING_SECONDS - (monotonic() - self._last_write_monotonic)
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+        self._last_write_monotonic = monotonic()
 
     async def close(self) -> None:
         """Close the session when done"""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -265,6 +265,64 @@ class TestACInfinityClient:
         with pytest.raises(ACInfinityClientCannotConnect):
             await client.update_device_controls(DEVICE_ID, 1, {DeviceControlKey.ON_SPEED: 5})
 
+    async def test_update_device_controls_skipped_when_values_already_match(self):
+        """When the requested values already match the existing settings, no update call is made.
+        Home Assistant does not dedupe same-value service calls, and redundant writes can trip
+        the AC Infinity API's failure window (#109)."""
+        client = ACInfinityClient(HOST, EMAIL, PASSWORD)
+        client._user_id = USER_ID
+        try:
+            with aioresponses() as mocked:
+                mocked.post(
+                    re.compile(rf"{HOST}{API_URL_GET_DEV_MODE_SETTING}.*"),
+                    status=200,
+                    payload=GET_DEV_MODE_SETTING_LIST_PAYLOAD,
+                )
+
+                await client.update_device_controls(
+                    DEVICE_ID, 4, {DeviceControlKey.ON_SPEED: DEVICE_CONTROLS[DeviceControlKey.ON_SPEED]}
+                )
+
+                for method, url in mocked.requests.keys():
+                    assert API_URL_ADD_DEV_MODE not in str(url), "No-op update should not call the update endpoint"
+        finally:
+            await client.close()
+
+    async def test_update_device_controls_write_spacing_applied_between_consecutive_writes(self, mocker):
+        """Consecutive writes are spaced out to avoid the API failure window triggered by
+        back to back update calls (#39, #109)."""
+        client = ACInfinityClient(HOST, EMAIL, PASSWORD)
+        client._user_id = USER_ID
+
+        sleep_mock = mocker.patch("custom_components.ac_infinity.client.asyncio.sleep")
+        mocker.patch(
+            "custom_components.ac_infinity.client.monotonic",
+            side_effect=[100.0, 101.0, 106.0],
+        )
+        try:
+            with aioresponses() as mocked:
+                mocked.post(
+                    re.compile(rf"{HOST}{API_URL_GET_DEV_MODE_SETTING}.*"),
+                    status=200,
+                    payload=GET_DEV_MODE_SETTING_LIST_PAYLOAD,
+                    repeat=True,
+                )
+
+                mocked.post(
+                    re.compile(f"{HOST}{API_URL_ADD_DEV_MODE}.*"),
+                    status=200,
+                    payload=UPDATE_SUCCESS_PAYLOAD,
+                    repeat=True,
+                )
+
+                await client.update_device_controls(DEVICE_ID, 4, {DeviceControlKey.ON_SPEED: 2})
+                await client.update_device_controls(DEVICE_ID, 4, {DeviceControlKey.ON_SPEED: 3})
+        finally:
+            await client.close()
+
+        sleep_mock.assert_awaited_once()
+        assert sleep_mock.await_args.args[0] == pytest.approx(4.0)
+
     @pytest.mark.parametrize("port", [0, 1, 2, 3, 4])
     async def test_get_device_settings_returns_settings(self, port: int):
         """When logged in, get controller settings should return the current settings"""
@@ -404,6 +462,30 @@ class TestACInfinityClient:
         assert AdvancedSettingsKey.DEV_NAME in payload
         assert payload[AdvancedSettingsKey.DEV_NAME] == DEVICE_NAME
 
+    async def test_update_device_settings_skipped_when_values_already_match(self):
+        """When the requested values already match the existing settings, no update call is made."""
+        client = ACInfinityClient(HOST, EMAIL, PASSWORD)
+        client._user_id = USER_ID
+        try:
+            with aioresponses() as mocked:
+                mocked.post(
+                    re.compile(rf"{HOST}{API_URL_GET_DEV_SETTING}"),
+                    status=200,
+                    payload=GET_DEV_SETTINGS_PAYLOAD,
+                )
+
+                await client.update_device_settings(
+                    DEVICE_ID,
+                    0,
+                    DEVICE_NAME,
+                    {AdvancedSettingsKey.CALIBRATE_HUMIDITY: DEVICE_SETTINGS[AdvancedSettingsKey.CALIBRATE_HUMIDITY]},
+                )
+
+                for method, url in mocked.requests.keys():
+                    assert API_URL_UPDATE_ADV_SETTING not in str(url), "No-op update should not call the update endpoint"
+        finally:
+            await client.close()
+
     @staticmethod
     async def __make_generic_update_ai_device_control_and_settings_call_and_get_sent_payload(
         dev_mode_payload=GET_DEV_MODE_SETTING_LIST_PAYLOAD,
@@ -465,6 +547,32 @@ class TestACInfinityClient:
         )
 
         assert payload[DeviceControlKey.ON_SPEED] == '3'
+
+    async def test_update_ai_device_control_and_settings_skipped_when_values_already_match(self):
+        """When the requested values already match the existing settings, no update call is made."""
+        client = ACInfinityClient(HOST, EMAIL, PASSWORD)
+        client._user_id = USER_ID
+        try:
+            with aioresponses() as mocked:
+                mocked.post(
+                    re.compile(rf"{HOST}{API_URL_GET_DEV_MODE_SETTING}.*"),
+                    status=200,
+                    payload=GET_DEV_MODE_SETTING_LIST_PAYLOAD,
+                )
+
+                await client.update_ai_device_control_and_settings(
+                    DEVICE_ID,
+                    1,
+                    {
+                        DeviceControlKey.AT_TYPE: DEVICE_CONTROLS[DeviceControlKey.AT_TYPE],
+                        DeviceControlKey.ON_SPEED: DEVICE_CONTROLS[DeviceControlKey.ON_SPEED],
+                    },
+                )
+
+                for method, url in mocked.requests.keys():
+                    assert API_URL_MODE_AND_SETTINGS not in str(url), "No-op update should not call the update endpoint"
+        finally:
+            await client.close()
 
     async def test_update_ai_device_control_and_settings_connect_error_on_not_logged_in(self):
         """When not logged in, update AI device control and settings should throw a connect error"""


### PR DESCRIPTION
Closes #109 (also relevant to #125, and possibly the silent-revert variant in #146)

## Problem

As diagnosed by @brookwarner in #109, the AC Infinity API enters a failure window when update calls arrive back to back: subsequent writes are rejected with `code 100001` until the API has been quiet for a while. Home Assistant does not dedupe same-value `number`/`select` service calls, so an automation that periodically re-sends an unchanged setpoint keeps the integration writing, which keeps the API inside the failure window indefinitely — in the reported case the setpoint was frozen for ~34 hours while reads kept working.

There is also a second, independent defect: the update flow is a read-modify-write (fetch settings list → merge new values → POST the full payload). Two concurrent writes (e.g. an automation setting `active_mode` and `on_power` in the same cycle) can interleave, so the second write's fetch happens before the first write lands, and the second POST silently reverts the first change.

## Changes (all in `ACInfinityClient`)

1. **Skip no-op writes.** After fetching current settings, if the outbound payload is identical to the current state, skip the cloud write. This makes writes idempotent at the client level and is the change that fixed the frozen-setpoint case in #109 — steady state now sends zero writes. Comparison is done on the normalized outbound payloads, so any type mismatch fails safe (it writes).
2. **Serialize writes.** The whole read-modify-write flow now runs under a per-client `asyncio.Lock`, so concurrent writes can no longer interleave and clobber each other.
3. **Space out consecutive writes.** A minimum 5-second gap is enforced between consecutive write requests (`MINIMUM_WRITE_SPACING_SECONDS`), as best-effort mitigation of the burst-triggered failure window. Happy to tune the value.

Read paths and polling are untouched.

## Testing

- Full suite passes: 1767 passed (1763 baseline + 4 new regression tests covering no-op skip on all three write methods and write spacing). `pyright` clean.
- The no-op-skip approach was verified against live hardware by @brookwarner in #109 (Cloudline S-series; commanded setpoint tracked again immediately, zero 100001s).
- Heads-up from my own live-API testing while investigating this: accounts that only have **shared** controllers (`isShare: 1`) get `code 999999` on every write endpoint (`addDevMode`, `updateAdvSetting`, `modeAndSetting`) — even for no-op payloads — so I could read but not write from my own fleet. That looks like a separate server-side permission behavior; I can file it as its own issue if useful.
