### PR TITLE
Don't let one misbehaving controller blank out the whole account

### DIFF
--- a/custom_components/ac_infinity/core.py
+++ b/custom_components/ac_infinity/core.py
@@ -321,21 +321,6 @@ class ACInfinityService:
 
     MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=5)
 
-    # api/user/devInfoListAll json organized by controller device id
-    _controller_properties: dict[str, Any] = {}
-
-    # api/user/devInfoListAll json organized by controller device id, sensor access port index, and sensor type.
-    _sensor_properties: dict[tuple[str, int, int], Any] = {}
-
-    # api/user/devInfoListAll json organized by controller device id and port index
-    _device_properties: dict[tuple[str, int], Any] = {}
-
-    # api/dev/getDevModeSettingList json organized by controller device id and port index
-    _device_controls: dict[tuple[str, int], Any] = {}
-
-    # api/dev/getDevSetting json organized by controller device id and port (index 0 represents controller settings)
-    _device_settings: dict[tuple[str, int], Any] = {}
-
     def __init__(
         self, client: ACInfinityClient
     ) -> None:
@@ -344,6 +329,24 @@ class ACInfinityService:
             client: The http client to use to make requests to the AC Infinity API
         """
         self._client = client
+
+        # These caches are instance state on purpose; as class attributes they would be
+        # shared between config entries, bleeding data across accounts.
+
+        # api/user/devInfoListAll json organized by controller device id
+        self._controller_properties: dict[str, Any] = {}
+
+        # api/user/devInfoListAll json organized by controller device id, sensor access port index, and sensor type.
+        self._sensor_properties: dict[tuple[str, int, int], Any] = {}
+
+        # api/user/devInfoListAll json organized by controller device id and port index
+        self._device_properties: dict[tuple[str, int], Any] = {}
+
+        # api/dev/getDevModeSettingList json organized by controller device id and port index
+        self._device_controls: dict[tuple[str, int], Any] = {}
+
+        # api/dev/getDevSetting json organized by controller device id and port (index 0 represents controller settings)
+        self._device_settings: dict[tuple[str, int], Any] = {}
 
     def get_device_ids(self) -> list[str]:
         """
@@ -600,38 +603,52 @@ class ACInfinityService:
 
                 all_devices_json = await self._client.get_account_controllers()
                 for controller_properties_json in all_devices_json:
-                    controller_id = controller_properties_json[ControllerPropertyKey.DEVICE_ID]
+                    controller_id = controller_properties_json.get(ControllerPropertyKey.DEVICE_ID)
+                    if controller_id is None:
+                        _LOGGER.warning("Skipping a controller with no device id in the devInfoListAll payload")
+                        continue
 
-                    # set controller properties; readings for temp, vpd, humidity, etc...
-                    self._controller_properties[str(controller_id)] = controller_properties_json
+                    # A single controller returning unexpected data must not fail the whole
+                    # refresh; e.g. devType 11 standalone fans report ports as null (#138).
+                    try:
+                        # set controller properties; readings for temp, vpd, humidity, etc...
+                        self._controller_properties[str(controller_id)] = controller_properties_json
 
-                    # retrieve and set controller settings; temperature, humidity, and vpd offsets
-                    controller_settings_json = await self._client.get_device_mode_settings(controller_id, 0)
-                    self._device_settings[(controller_id, 0)] = controller_settings_json[DeviceControlKey.DEV_SETTING]
+                        # retrieve and set controller settings; temperature, humidity, and vpd offsets
+                        controller_settings_json = await self._client.get_device_mode_settings(controller_id, 0)
+                        self._device_settings[(controller_id, 0)] = controller_settings_json[DeviceControlKey.DEV_SETTING]
 
-                    # controller AI will have a sensor array.
-                    if ControllerPropertyKey.SENSORS in controller_properties_json[ControllerPropertyKey.DEVICE_INFO]:
-                        sensors = controller_properties_json[ControllerPropertyKey.DEVICE_INFO][ControllerPropertyKey.SENSORS] or []
-                        for sensor_properties_json in sensors:
-                            access_port_index = sensor_properties_json[SensorPropertyKey.ACCESS_PORT]
-                            sensor_type = sensor_properties_json[SensorPropertyKey.SENSOR_TYPE]
+                        # controller AI will have a sensor array.
+                        if ControllerPropertyKey.SENSORS in controller_properties_json[ControllerPropertyKey.DEVICE_INFO]:
+                            sensors = controller_properties_json[ControllerPropertyKey.DEVICE_INFO][ControllerPropertyKey.SENSORS] or []
+                            for sensor_properties_json in sensors:
+                                access_port_index = sensor_properties_json[SensorPropertyKey.ACCESS_PORT]
+                                sensor_type = sensor_properties_json[SensorPropertyKey.SENSOR_TYPE]
 
-                            # set sensor properties; sensor value, unit, and display precision
-                            self._sensor_properties[(controller_id, access_port_index, sensor_type)] = sensor_properties_json
+                                # set sensor properties; sensor value, unit, and display precision
+                                self._sensor_properties[(controller_id, access_port_index, sensor_type)] = sensor_properties_json
 
-                    for device_properties_json in controller_properties_json[ControllerPropertyKey.DEVICE_INFO][ControllerPropertyKey.PORTS]:
-                        device_port = device_properties_json[DevicePropertyKey.PORT]
+                        ports = controller_properties_json[ControllerPropertyKey.DEVICE_INFO][ControllerPropertyKey.PORTS] or []
+                        for device_properties_json in ports:
+                            device_port = device_properties_json[DevicePropertyKey.PORT]
 
-                        # set port properties; current power and remaining time until a mode switch
-                        self._device_properties[(controller_id, device_port)] = device_properties_json
+                            # set port properties; current power and remaining time until a mode switch
+                            self._device_properties[(controller_id, device_port)] = device_properties_json
 
-                        # retrieve and set port controls; current mode, temperature triggers, on/off speed, etc...
-                        device_controls_json = await self._client.get_device_mode_settings(controller_id, device_port)
-                        self._device_controls[(controller_id, device_port)] = device_controls_json
+                            # retrieve and set port controls; current mode, temperature triggers, on/off speed, etc...
+                            device_controls_json = await self._client.get_device_mode_settings(controller_id, device_port)
+                            self._device_controls[(controller_id, device_port)] = device_controls_json
 
-                        # retrieve and set port settings; Dynamic Response, Transition values, Buffer values, etc..
-                        device_settings_json = await self._client.get_device_mode_settings(controller_id, device_port)
-                        self._device_settings[(controller_id, device_port)] = device_settings_json[DeviceControlKey.DEV_SETTING]
+                            # retrieve and set port settings; Dynamic Response, Transition values, Buffer values, etc..
+                            device_settings_json = await self._client.get_device_mode_settings(controller_id, device_port)
+                            self._device_settings[(controller_id, device_port)] = device_settings_json[DeviceControlKey.DEV_SETTING]
+                    except (ACInfinityClientRequestFailed, KeyError, TypeError, ValueError) as ex:
+                        _LOGGER.warning(
+                            "Skipping controller %s for this refresh; it returned unexpected data. Other controllers are unaffected.",
+                            controller_id,
+                            exc_info=ex,
+                        )
+                        continue
 
                 return  # update successful.  eject from the infinite while loop.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 from asyncio import Future
 
 import aiohttp
@@ -207,6 +208,55 @@ class TestACInfinity:
 
         # Should NOT retry on unexpected exceptions
         assert mock_client.get_account_controllers.call_count == 1
+
+    async def test_refresh_tolerates_controller_with_null_ports(self, mock_client):
+        """A controller reporting ports as null (#138) must not fail the whole refresh
+        and blank out every other controller."""
+        devices = copy.deepcopy(DEVICE_INFO_LIST_ALL)
+        devices[0][ControllerPropertyKey.DEVICE_INFO][ControllerPropertyKey.PORTS] = None
+        null_ports_id = devices[0][ControllerPropertyKey.DEVICE_ID]
+        healthy_id = devices[1][ControllerPropertyKey.DEVICE_ID]
+
+        mock_client.is_logged_in.return_value = True
+        mock_client.get_account_controllers.return_value = devices
+        mock_client.get_device_mode_settings.return_value = DEVICE_CONTROLS
+
+        ac_infinity = ACInfinityService(mock_client)
+        await ac_infinity.refresh()
+
+        # both controllers keep their controller level data
+        assert str(null_ports_id) in ac_infinity._controller_properties
+        assert str(healthy_id) in ac_infinity._controller_properties
+
+        # the healthy controller still gets its port data
+        assert any(key[0] == healthy_id for key in ac_infinity._device_properties)
+        assert not any(key[0] == null_ports_id for key in ac_infinity._device_properties)
+
+    async def test_refresh_skips_controller_when_its_settings_call_fails(self, mock_client):
+        """A controller whose settings fetch fails must not fail the whole refresh
+        and blank out every other controller."""
+        mock_client.is_logged_in.return_value = True
+        mock_client.get_account_controllers.return_value = DEVICE_INFO_LIST_ALL
+
+        def get_device_mode_settings(controller_id, port):
+            if str(controller_id) == str(DEVICE_ID):
+                raise ACInfinityClientRequestFailed({"msg": "Operation failed", "code": 999999})
+            return DEVICE_CONTROLS
+
+        mock_client.get_device_mode_settings.side_effect = get_device_mode_settings
+
+        ac_infinity = ACInfinityService(mock_client)
+        await ac_infinity.refresh()
+
+        # the failing controller is skipped without retrying the whole refresh
+        assert mock_client.get_account_controllers.call_count == 1
+
+        # the healthy controller is fully refreshed
+        ai_id = DEVICE_INFO_LIST_ALL[1][ControllerPropertyKey.DEVICE_ID]
+        assert str(ai_id) in ac_infinity._controller_properties
+        assert (ai_id, 0) in ac_infinity._device_settings
+        assert not any(key[0] == DEVICE_INFO_LIST_ALL[0][ControllerPropertyKey.DEVICE_ID]
+                       for key in ac_infinity._device_settings)
 
     @pytest.mark.parametrize(
         "property_key, value",


### PR DESCRIPTION
Addresses the first problem in #138, and a failure mode where the whole integration goes blank because of a single device.

## Problem

`ACInfinityService.refresh()` is all-or-nothing: it loops over every controller on the account and fetches settings for every port, and any exception fails the entire refresh. After the retry limit, the coordinator marks the update failed and **every entity of every controller becomes unavailable** — indefinitely, since the same device fails the same way on every poll. Removing and re-adding the integration does not help (the first refresh fails the same way).

Known triggers:

- devType 11 standalone fans report `ports: null` in `devInfoListAll` (#138) → `TypeError: 'NoneType' object is not iterable`
- a single controller whose `getdevModeSettingList` call fails (non-200 `code`) while the rest of the account is healthy
- any future payload-shape surprise on any one device (`KeyError`, etc.)

The practical symptom users see: all devices present in HA, every value blank/unavailable, often right after adding a new device to their AC Infinity account.

## Changes

1. Guard the `ports` array with `or []`, matching how the `sensors` array is already guarded two lines above. Controllers that report `ports: null` (#138) now keep their controller-level sensors instead of taking down the account.
2. Wrap the per-controller portion of `refresh()` so a controller that returns unexpected data (`ACInfinityClientRequestFailed`, `KeyError`, `TypeError`, `ValueError`) is skipped with a warning while every other controller refreshes normally. Connection-level failures (`CannotConnect`, `aiohttp.ClientError`, timeouts) still propagate to the existing retry logic, since those affect the whole API session rather than one device.
3. Make the service's data caches (`_controller_properties`, `_device_properties`, etc.) instance state. They were class attributes, i.e. shared between all `ACInfinityService` instances — with two config entries (two accounts) in one HA instance, data would bleed between accounts.

## Testing

- Full suite passes: 1765 (1763 baseline + 2 new regression tests: `ports: null` on one controller, and a failing settings call on one controller — both assert the healthy controller still refreshes). `pyright` clean.
- The instance-state change is also what makes these tests deterministic — with class-level dicts, state leaked between test cases.

Independent of #149 (write path); the two merge cleanly in either order.
