### PR TITLE
Fetch each port once and drop the fixed 10 second refresh timeout

### DIFF
--- a/custom_components/ac_infinity/core.py
+++ b/custom_components/ac_infinity/core.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 from typing import Any, Callable
 
 import aiohttp
-import async_timeout
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -625,13 +624,12 @@ class ACInfinityService:
                         # set port properties; current power and remaining time until a mode switch
                         self._device_properties[(controller_id, device_port)] = device_properties_json
 
-                        # retrieve and set port controls; current mode, temperature triggers, on/off speed, etc...
+                        # retrieve and set port controls (current mode, temperature triggers, on/off speed, etc...)
+                        # and port settings (Dynamic Response, Transition values, Buffer values, etc..).
+                        # both come from the same response; fetching it twice doubles the refresh time.
                         device_controls_json = await self._client.get_device_mode_settings(controller_id, device_port)
                         self._device_controls[(controller_id, device_port)] = device_controls_json
-
-                        # retrieve and set port settings; Dynamic Response, Transition values, Buffer values, etc..
-                        device_settings_json = await self._client.get_device_mode_settings(controller_id, device_port)
-                        self._device_settings[(controller_id, device_port)] = device_settings_json[DeviceControlKey.DEV_SETTING]
+                        self._device_settings[(controller_id, device_port)] = device_controls_json[DeviceControlKey.DEV_SETTING]
 
                 return  # update successful.  eject from the infinite while loop.
 
@@ -898,9 +896,13 @@ class ACInfinityDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch data from the AC Infinity API"""
         _LOGGER.debug("Refreshing data from data update coordinator")
         try:
-            async with async_timeout.timeout(10):
-                await self._ac_infinity.refresh()
-                return self._ac_infinity
+            # No overall timeout here: refresh makes one request per controller plus one per
+            # port, each with its own 10 second timeout in the client.  A fixed overall
+            # timeout puts a hard ceiling on account size; accounts with more than a few
+            # controllers could never complete a refresh, permanently marking every
+            # entity unavailable.
+            await self._ac_infinity.refresh()
+            return self._ac_infinity
         except Exception as e:
             raise UpdateFailed from e
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -124,6 +124,34 @@ class TestACInfinity:
             == "Grow Tent AI"
         )
 
+    async def test_refresh_fetches_each_port_only_once(self, mock_client):
+        """Port controls and port settings come from the same API response.  Fetching each
+        port twice doubles the refresh duration, which for accounts with many controllers
+        makes the refresh permanently exceed the coordinator update window."""
+        mock_client.is_logged_in.return_value = True
+        mock_client.get_account_controllers.return_value = DEVICE_INFO_LIST_ALL
+        mock_client.get_device_mode_settings.return_value = DEVICE_CONTROLS
+
+        ac_infinity = ACInfinityService(mock_client)
+        await ac_infinity.refresh()
+
+        expected_calls = 0
+        for controller in DEVICE_INFO_LIST_ALL:
+            expected_calls += 1  # controller settings via port 0
+            expected_calls += len(
+                controller[ControllerPropertyKey.DEVICE_INFO][ControllerPropertyKey.PORTS] or []
+            )
+
+        assert mock_client.get_device_mode_settings.call_count == expected_calls
+
+        # both controls and settings are populated from the single fetch
+        for controller in DEVICE_INFO_LIST_ALL:
+            controller_id = controller[ControllerPropertyKey.DEVICE_ID]
+            for port in controller[ControllerPropertyKey.DEVICE_INFO][ControllerPropertyKey.PORTS] or []:
+                device_port = port[DevicePropertyKey.PORT]
+                assert (controller_id, device_port) in ac_infinity._device_controls
+                assert (controller_id, device_port) in ac_infinity._device_settings
+
     async def test_update_retried_on_failure(self, mocker: MockFixture, mock_client):
         """update should be tried 5 times before raising an exception"""
         future: Future = asyncio.Future()


### PR DESCRIPTION
## Problem

`ACInfinityDataUpdateCoordinator._async_update_data` wraps the entire refresh in a fixed `async_timeout.timeout(10)`. But `refresh()` makes one sequential API call per controller plus per port — and it currently fetches every port **twice**, since port controls and port settings both come from the same `getdevModeSettingList` response.

Refresh duration therefore grows linearly with account size. Measured against a real account with 13 controllers / 68 ports: 150 sequential calls at ~288 ms/call with connection reuse ≈ **43 seconds** — against a 10 second ceiling. Once an account grows past roughly 3 controllers' worth of ports, no refresh can ever complete: every poll times out, `UpdateFailed` is raised, and **every entity of every controller is permanently unavailable**. Removing and re-adding the integration doesn't help, because the first refresh fails the same way.

The user-visible symptom is "the integration just stopped getting data one day" — the day the account crossed the size threshold. Field-confirmed: a user with exactly this symptom (all devices visible, every value blank, reinstall didn't help) had data restored immediately by this change.

This may also explain the anomalous ~1m49s polling gap in the debug log attached to #146.

## Changes

1. **Fetch each port once.** Store both port controls and port settings from a single `getdevModeSettingList` response instead of requesting it twice. Halves the number of calls per refresh.
2. **Remove the overall 10 second refresh timeout.** Every request already has its own 10 second timeout inside the client, and the retry logic bounds failures, so total refresh duration is already bounded — the blanket wrapper adds nothing except a hard ceiling on account size.

For users with larger accounts it's still worth raising the polling interval in the integration options, since a refresh that takes ~20 s shouldn't be scheduled every 10 s — but with this change a large account degrades to "slow" instead of "permanently unavailable". (Parallelizing the per-port fetches would speed this up further, but given the API's sensitivity to request bursts (#39) I kept this PR to the conservative fixes.)

## Testing

- Full suite passes: 1764 (1763 baseline + 1 new regression test asserting exactly one settings fetch per port, with controls and settings both populated from it). `pyright` clean.
- Field-verified on a 13-controller account that was fully dead on 2.2.0: data returned immediately after installing a build with this change.

Independent of #149 and #150; merges cleanly with both.
