### PR TITLE
Add support for room-to-room/through-wall fans (AC-TWT6, devType 33)

### DIFF
--- a/custom_components/ac_infinity/const.py
+++ b/custom_components/ac_infinity/const.py
@@ -85,6 +85,9 @@ class ControllerPropertyKey:
     TIME_ZONE = "zoneId"
     SENSORS = "sensors"
     PORT_COUNT = "devPortCount"
+    # Room-to-room/through-wall fans (e.g. AC-TWT6) report these instead of TEMPERATURE.
+    INSIDE_TEMP = "insideTemp"
+    OUTSIDE_TEMP = "outsideTemp"
 
 
 class ControllerType:
@@ -93,12 +96,22 @@ class ControllerType:
     UIS_89_AI_PLUS = 20
     UIS_OUTLET_AI = 21
     UIS_OUTLET_AI_PLUS = 22
+    # Standalone WiFi room-to-room / through-wall fan (e.g. AC-TWT6). Unlike the
+    # UIS tent controllers, it has no ports and reports two independent zone
+    # readings (insideTemp/outsideTemp) instead of one top-level "temperature".
+    UIS_ROOM_TO_ROOM_FAN = 33
 
 
 AI_CONTROLLER_TYPES = frozenset({
     ControllerType.UIS_89_AI_PLUS,
     ControllerType.UIS_OUTLET_AI,
     ControllerType.UIS_OUTLET_AI_PLUS
+})
+
+# Devices whose top-level "temperature"/"humidity" fields are stale/unused, and
+# whose real readings live under insideTemp/outsideTemp instead.
+ROOM_TO_ROOM_FAN_CONTROLLER_TYPES = frozenset({
+    ControllerType.UIS_ROOM_TO_ROOM_FAN
 })
 
 

--- a/custom_components/ac_infinity/core.py
+++ b/custom_components/ac_infinity/core.py
@@ -21,6 +21,7 @@ from custom_components.ac_infinity.client import ACInfinityClient, ACInfinityCli
     ACInfinityClientCannotConnect, ACInfinityClientRequestFailed
 from .const import (
     AI_CONTROLLER_TYPES,
+    ROOM_TO_ROOM_FAN_CONTROLLER_TYPES,
     DOMAIN,
     MANUFACTURER,
     ControllerPropertyKey,
@@ -95,6 +96,11 @@ class ACInfinityController:
         return self._controller_type in AI_CONTROLLER_TYPES
 
     @property
+    def is_room_to_room_fan(self) -> bool:
+        """Returns true if this is a standalone room-to-room/through-wall fan (e.g. AC-TWT6)"""
+        return self._controller_type in ROOM_TO_ROOM_FAN_CONTROLLER_TYPES
+
+    @property
     def mac_addr(self) -> str:
         """The unique mac address of the UIS controller's WI-FI network interface"""
         return self._mac_addr
@@ -132,6 +138,8 @@ class ACInfinityController:
                 return "UIS Controller Outlet AI (AC-ADA4)"
             case ControllerType.UIS_OUTLET_AI_PLUS:
                 return "UIS Controller Outlet AI+ (AC-ADA8)"
+            case ControllerType.UIS_ROOM_TO_ROOM_FAN:
+                return "Room to Room Fan (AC-TWT6)"
             case _:
                 return f"UIS Controller Type {device_type}"
 

--- a/custom_components/ac_infinity/sensor.py
+++ b/custom_components/ac_infinity/sensor.py
@@ -99,6 +99,26 @@ def __suitable_fn_controller_property_default(
     )
 
 
+def __suitable_fn_controller_temperature(
+    entity: ACInfinityEntity, controller: ACInfinityController
+):
+    # Standalone room-to-room/through-wall fans (e.g. AC-TWT6) populate the top-level
+    # "temperature" field with a stale/unused value that doesn't match either zone's
+    # actual reading. Their real temperatures live in insideTemp/outsideTemp instead,
+    # exposed via the dedicated descriptions below.
+    if controller.is_room_to_room_fan:
+        return False
+    return __suitable_fn_controller_property_default(entity, controller)
+
+
+def __suitable_fn_room_to_room_zone_temperature(
+    entity: ACInfinityEntity, controller: ACInfinityController
+):
+    return controller.is_room_to_room_fan and entity.ac_infinity.get_controller_property_exists(
+        controller.controller_id, entity.data_key
+    )
+
+
 def __suitable_fn_sensor_default(entity: ACInfinityEntity, sensor: ACInfinitySensor):
     return entity.ac_infinity.get_sensor_property_exists(
         sensor.controller.controller_id,
@@ -245,7 +265,31 @@ CONTROLLER_DESCRIPTIONS: list[ACInfinityControllerSensorEntityDescription] = [
         icon=None,  # default
         translation_key="temperature",
         enabled_fn=enabled_fn_sensor,
-        suitable_fn=__suitable_fn_controller_property_default,
+        suitable_fn=__suitable_fn_controller_temperature,
+        get_value_fn=__get_value_fn_floating_point_as_int,
+    ),
+    ACInfinityControllerSensorEntityDescription(
+        key=ControllerPropertyKey.INSIDE_TEMP,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        suggested_unit_of_measurement=None,
+        icon=None,  # default
+        translation_key="inside_temperature",
+        enabled_fn=enabled_fn_sensor,
+        suitable_fn=__suitable_fn_room_to_room_zone_temperature,
+        get_value_fn=__get_value_fn_floating_point_as_int,
+    ),
+    ACInfinityControllerSensorEntityDescription(
+        key=ControllerPropertyKey.OUTSIDE_TEMP,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        suggested_unit_of_measurement=None,
+        icon=None,  # default
+        translation_key="outside_temperature",
+        enabled_fn=enabled_fn_sensor,
+        suitable_fn=__suitable_fn_room_to_room_zone_temperature,
         get_value_fn=__get_value_fn_floating_point_as_int,
     ),
     ACInfinityControllerSensorEntityDescription(

--- a/custom_components/ac_infinity/strings.json
+++ b/custom_components/ac_infinity/strings.json
@@ -267,6 +267,12 @@
       },
       "next_state_change": {
         "name": "Next State Change"
+      },
+      "inside_temperature": {
+        "name": "Inside Temperature"
+      },
+      "outside_temperature": {
+        "name": "Outside Temperature"
       }
     },
     "switch": {

--- a/custom_components/ac_infinity/translations/en.json
+++ b/custom_components/ac_infinity/translations/en.json
@@ -267,6 +267,12 @@
       },
       "next_state_change": {
         "name": "Next State Change"
+      },
+      "inside_temperature": {
+        "name": "Inside Temperature"
+      },
+      "outside_temperature": {
+        "name": "Outside Temperature"
       }
     },
     "switch": {

--- a/tests/test_room_to_room_fan.py
+++ b/tests/test_room_to_room_fan.py
@@ -1,0 +1,126 @@
+"""
+Regression tests for standalone room-to-room/through-wall fans (e.g. AC-TWT6,
+devType 33). These devices have no ports and report insideTemp/outsideTemp
+instead of a meaningful top-level "temperature" field.
+
+This uses a sanitized capture of a real AC-TWT6's /api/user/devInfoListAll
+entry (identifiers replaced) rather than the shared global fixtures in
+data_models.py, since mutating those shared dicts would leak state into
+unrelated test files.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.ac_infinity.client import ACInfinityClient
+from custom_components.ac_infinity.const import ControllerPropertyKey, ControllerType
+from custom_components.ac_infinity.core import ACInfinityController, ACInfinityService
+from custom_components.ac_infinity.sensor import CONTROLLER_DESCRIPTIONS
+
+DEVICE_ID = "1111111111111111111"
+MAC_ADDR = "AABBCCDDEEFF"
+
+# Sanitized real-world capture of a devInfoListAll entry for an AC-TWT6.
+ROOM_TO_ROOM_FAN_PROPERTIES = {
+    "devId": DEVICE_ID,
+    "devCode": "WA028",
+    "devName": "Test Fan",
+    "devType": ControllerType.UIS_ROOM_TO_ROOM_FAN,
+    "devPortCount": 0,
+    "devMacAddr": MAC_ADDR,
+    "devVersion": 9,
+    "online": 1,
+    "isShare": 0,
+    "devExternalList": None,
+    "deviceInfo": {
+        "devMacAddr": MAC_ADDR,
+        "devId": DEVICE_ID,
+        "temperature": 1860,  # stale/unused on this device type -- should be hidden
+        "temperatureF": None,
+        "humidity": 0,
+        "unit": 0,
+        "ports": [],
+        "insideTemp": 2346,
+        "insideTempF": 7423,
+        "outsideTemp": 2260,
+        "outsideTempF": 7268,
+        "insideRoomName": "Utility Room",
+        "outsideRoomName": "Living Room",
+        "roomToRoomFan": True,
+    },
+    "appEmail": "test@example.com",
+    "firmwareVersion": "3.0.31",
+    "hardwareVersion": "3.0",
+    "zoneId": "America/New_York",
+}
+
+
+def _get_description(key: str):
+    matches = [d for d in CONTROLLER_DESCRIPTIONS if d.key == key]
+    assert len(matches) == 1, f"expected exactly one description for {key}"
+    return matches[0]
+
+
+@pytest.fixture
+def controller_and_service():
+    client = ACInfinityClient("http://unittest.abcxyz", "test@example.com", "hunter2")
+    service = ACInfinityService(client)
+    service._controller_properties = {DEVICE_ID: ROOM_TO_ROOM_FAN_PROPERTIES}
+    controller = ACInfinityController(ROOM_TO_ROOM_FAN_PROPERTIES)
+    return controller, service
+
+
+class TestRoomToRoomFan:
+    def test_is_room_to_room_fan_true_for_devtype_33(self, controller_and_service):
+        controller, _ = controller_and_service
+        assert controller.is_room_to_room_fan is True
+        assert controller.is_ai_controller is False
+
+    def test_generic_temperature_sensor_not_suitable(self, controller_and_service):
+        """The stale top-level 'temperature' field must not be surfaced for this device type."""
+        controller, service = controller_and_service
+        description = _get_description(ControllerPropertyKey.TEMPERATURE)
+        entity = SimpleNamespace(data_key=description.key, ac_infinity=service)
+
+        assert description.suitable_fn(entity, controller) is False
+
+    def test_inside_temperature_sensor_suitable_and_correct(self, controller_and_service):
+        controller, service = controller_and_service
+        description = _get_description(ControllerPropertyKey.INSIDE_TEMP)
+        entity = SimpleNamespace(data_key=description.key, ac_infinity=service)
+
+        assert description.suitable_fn(entity, controller) is True
+        assert description.get_value_fn(entity, controller) == 23.46
+
+    def test_outside_temperature_sensor_suitable_and_correct(self, controller_and_service):
+        controller, service = controller_and_service
+        description = _get_description(ControllerPropertyKey.OUTSIDE_TEMP)
+        entity = SimpleNamespace(data_key=description.key, ac_infinity=service)
+
+        assert description.suitable_fn(entity, controller) is True
+        assert description.get_value_fn(entity, controller) == 22.60
+
+    def test_inside_outside_not_suitable_for_non_room_to_room_controllers(self):
+        """A regular 69 Pro controller (no insideTemp/outsideTemp) shouldn't get these sensors."""
+        client = ACInfinityClient("http://unittest.abcxyz", "test@example.com", "hunter2")
+        service = ACInfinityService(client)
+
+        regular_properties = {
+            **ROOM_TO_ROOM_FAN_PROPERTIES,
+            "devType": ControllerType.UIS_69_PRO,
+        }
+        service._controller_properties = {DEVICE_ID: regular_properties}
+        controller = ACInfinityController(regular_properties)
+
+        inside_description = _get_description(ControllerPropertyKey.INSIDE_TEMP)
+        outside_description = _get_description(ControllerPropertyKey.OUTSIDE_TEMP)
+        temperature_description = _get_description(ControllerPropertyKey.TEMPERATURE)
+
+        entity = SimpleNamespace(data_key=inside_description.key, ac_infinity=service)
+        assert inside_description.suitable_fn(entity, controller) is False
+
+        entity = SimpleNamespace(data_key=outside_description.key, ac_infinity=service)
+        assert outside_description.suitable_fn(entity, controller) is False
+
+        entity = SimpleNamespace(data_key=temperature_description.key, ac_infinity=service)
+        assert temperature_description.suitable_fn(entity, controller) is True


### PR DESCRIPTION
These standalone WiFi fans (e.g. AC-TWT6) have no ports and report a stale/unused top-level "temperature" field that doesn't match either of the device's two actual zone readings. Real values live in insideTemp/outsideTemp instead, which were previously unused by the integration.

- const.py: add ControllerType.UIS_ROOM_TO_ROOM_FAN (33) and proper ControllerPropertyKey.INSIDE_TEMP/OUTSIDE_TEMP constants (these keys previously only existed under unrelated per-port setting classes)
- core.py: add ACInfinityController.is_room_to_room_fan and a real device model name instead of the generic "UIS Controller Type 33"
- sensor.py: hide the generic Temperature sensor for room-to-room fans and add dedicated Inside Temperature / Outside Temperature sensors
- strings.json / translations/en.json: names for the new entities
- tests/test_room_to_room_fan.py: regression tests built from a sanitized capture of a real AC-TWT6's devInfoListAll payload

Verified against the real device's payload:
  temperature (unused):  1860  -> 18.60C / 65.48F (matches neither zone) insideTemp/insideTempF:  2346 / 7423 -> 23.46C / 74.23F (consistent) outsideTemp/outsideTempF: 2260 / 7268 -> 22.60C / 72.68F (consistent)